### PR TITLE
Unique IDs for all points

### DIFF
--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -9,47 +9,47 @@ AK7,Alatna,Alaasuq,Alaska,US,66.5542,-152.7019
 AK8,Aleknagik,Alaqnaqiq,Alaska,US,59.273,-158.618
 AK9,Aleut Village,,Alaska,US,58.0171,-152.761
 AK10,Alexander Creek,Alexander,Alaska,US,61.4171,-150.593
-AK11,Allakaket,Aalaa Kkaakk’et,Alaska,US,66.5656,-152.64600000000002
+AK11,Allakaket,Aalaa Kkaakk’et,Alaska,US,66.5656,-152.646
 AK12,Ambler,Ivisaappaat,Alaska,US,67.0861,-157.851
 AK13,Anaktuvuk Pass,Anaqtuuvak,Alaska,US,68.1433,-151.736
-AK14,Anchor Point,K’kaq’,Alaska,US,59.7766,-151.83100000000002
+AK14,Anchor Point,K’kaq’,Alaska,US,59.7766,-151.831
 AK15,Anchorage,Dgheyaytnu,Alaska,US,61.1817,-149.993
 AK16,Anderson,,Alaska,US,64.3441,-149.187
 AK17,Andreafsky,Negeqliq,Alaska,US,62.0501,-163.167
 AK18,Angoon,Aangóon,Alaska,US,57.5033,-134.584
-AK19,Aniak,Anyaraq,Alaska,US,61.5783,-159.52200000000002
+AK19,Aniak,Anyaraq,Alaska,US,61.5783,-159.522
 AK20,Annette,,Alaska,US,55.063,-131.541
 AK21,Anvik,Gitr'ingith Chagg,Alaska,US,62.6561,-160.207
-AK22,Arctic Village,Vashrąįį K'ǫǫ,Alaska,US,68.1269,-145.53799999999998
-AK23,Atka,Atx̂ax̂,Alaska,US,52.191,-174.18900000000002
+AK22,Arctic Village,Vashrąįį K'ǫǫ,Alaska,US,68.1269,-145.538
+AK23,Atka,Atx̂ax̂,Alaska,US,52.191,-174.189
 AK24,Atmautluak,Atmaulluaq,Alaska,US,60.8641,-162.2723
-AK25,Atqasuk,,Alaska,US,70.4694,-157.39600000000002
+AK25,Atqasuk,,Alaska,US,70.4694,-157.396
 AK26,Attu,,Alaska,US,52.9365,173.24
 AK27,Auke Bay,,Alaska,US,58.383,-134.657
 AK28,Ayakulik,,Alaska,US,57.2113,-154.546
 AK29,Baranof Warm Springs,,Alaska,US,57.0895,-134.8337
 AK30,Bartlett Cove,,Alaska,US,58.45,-135.916
-AK31,Beaver,Ts'aahudaaneekk'onh Denh,Alaska,US,66.3594,-147.39600000000002
+AK31,Beaver,Ts'aahudaaneekk'onh Denh,Alaska,US,66.3594,-147.396
 AK32,Belkofski,Taxtamax̂,Alaska,US,55.0905,-162.034
 AK33,Bell Island Hot Springs,,Alaska,US,55.933,-131.566
 AK34,Belmezok,,Alaska,US,65.6172,-168.101
-AK35,Bessie No. 5 Dredge,,Alaska,US,64.5502,-165.15099999999998
+AK35,Bessie No. 5 Dredge,,Alaska,US,64.5502,-165.151
 AK36,Bethel,Mamterilleq,Alaska,US,60.7922,-161.756
 AK37,Bettles,Kk’odlel T’odegheelenh Denh,Alaska,US,66.9185,-151.5162
 AK38,Big Delta,,Alaska,US,64.1525,-145.842
-AK39,Big Lake,,Alaska,US,61.5378,-149.82399999999998
+AK39,Big Lake,,Alaska,US,61.5378,-149.824
 AK40,Bill Moores,,Alaska,US,62.9504,-163.7777
 AK41,Biorka,,Alaska,US,53.831,-166.208
-AK42,Birch Creek,Łiteet'aii,Alaska,US,66.2687,-145.82399999999998
+AK42,Birch Creek,Łiteet'aii,Alaska,US,66.2687,-145.824
 AK43,Birchwood,,Alaska,US,61.4081,-149.481
 AK44,Bird Point,,Alaska,US,60.9311,-149.358
 AK45,Bodenburg Butte,,Alaska,US,61.5495,-149.047
-AK46,Boswell Bay,,Alaska,US,60.4001,-146.13299999999998
+AK46,Boswell Bay,,Alaska,US,60.4001,-146.133
 AK47,Brevig Mission,Sitaisaq / Sinauraq,Alaska,US,65.3347,-166.489
 AK48,Buckland,Kaŋiq,Alaska,US,65.9797,-161.123
 AK49,Candle,,Alaska,US,65.9133,-161.924
 AK50,Cantwell,Yidateni Na’,Alaska,US,63.3917,-148.951
-AK51,Cape Lisburne,,Alaska,US,68.8678,-166.19299999999998
+AK51,Cape Lisburne,,Alaska,US,68.8678,-166.193
 AK52,Cape Pole,,Alaska,US,55.965,-133.798
 AK53,Cape Yakataga,,Alaska,US,60.0652,-142.428
 AK54,Central,,Alaska,US,65.5724,-144.803
@@ -58,14 +58,14 @@ AK56,Chakwaktolik,,Alaska,US,61.2291,-163.754
 AK57,Chalkyitsik,Jałgiitsik,Alaska,US,66.6544,-143.722
 AK58,Chaniliut,,Alaska,US,63.0332,-163.417
 AK59,Charlieskin Village,,Alaska,US,62.9672,-141.816
-AK60,Chatham,,Alaska,US,57.513999999999996,-134.924
+AK60,Chatham,,Alaska,US,57.514,-134.924
 AK61,Chefornak,Cevvʼarneq / Caputnguaq,Alaska,US,60.1607,-164.271
 AK62,Chena Hot Springs,,Alaska,US,65.053,-146.056
 AK63,Chenega Bay,Caniqaq,Alaska,US,60.0746,-148.003
-AK64,Chevak,Cevʼaq,Alaska,US,61.5278,-165.58599999999998
+AK64,Chevak,Cevʼaq,Alaska,US,61.5278,-165.586
 AK65,Chickaloon,Nay’dini’aa Na’,Alaska,US,61.7967,-148.463
 AK66,Chicken,,Alaska,US,64.0733,-141.936
-AK67,Chignik,Cirniq,Alaska,US,56.2953,-158.40200000000002
+AK67,Chignik,Cirniq,Alaska,US,56.2953,-158.402
 AK68,Chignik Lagoon,Nanwarnaq,Alaska,US,56.3104,-158.5361
 AK69,Chignik Lake,Igyaraq,Alaska,US,56.2552,-158.7696
 AK70,Chiniak,Cing’iyak,Alaska,US,57.617,-152.2166
@@ -78,7 +78,7 @@ AK76,Chuloonawick,,Alaska,US,62.8961,-163.894
 AK77,Circle,Danzhit Khànląįį,Alaska,US,65.8255,-144.061
 AK78,Circle Hot Springs,,Alaska,US,65.4833,-144.634
 AK79,Clam Gulch,Qałnigi D’nazludt,Alaska,US,60.2311,-151.394
-AK80,Clark's Point,Saguyaq,Alaska,US,58.8441,-158.55100000000002
+AK80,Clark's Point,Saguyaq,Alaska,US,58.8441,-158.551
 AK81,Clear,,Alaska,US,64.3332,-149.167
 AK82,Clover Pass,,Alaska,US,55.472,-131.791
 AK83,Coffman Cove,,Alaska,US,56.0119,-132.8296
@@ -88,18 +88,18 @@ AK86,College,Trothyeddha',Alaska,US,64.8582,-147.808
 AK87,Cooper Landing,,Alaska,US,60.4906,-149.833
 AK88,Copper Center,Tl’aticae’e,Alaska,US,61.955,-145.305
 AK89,Cordova,The Crossroads of Alaska,Alaska,US,60.5428,-145.757
-AK90,Council,,Alaska,US,64.895,-163.67600000000002
+AK90,Council,,Alaska,US,64.895,-163.676
 AK91,Craig,Sháan Séet,Alaska,US,55.4764,-133.148
 AK92,Crooked Creek,Qipcarpak,Alaska,US,61.87,-158.111
 AK93,Deadhorse,,Alaska,US,70.2097,-148.418
 AK94,Deering,Ipnatchiaq,Alaska,US,66.0755,-162.717
 AK95,Delta Junction,,Alaska,US,64.0377,-145.732
 AK96,Dillingham,Curyung,Alaska,US,59.0397,-158.457
-AK97,Diomede,Iŋaliq,Alaska,US,65.7648,-168.91099999999997
-AK98,Dot Lake,Kelt’aaddh Menn’,Alaska,US,63.663000000000004,-144.049
+AK97,Diomede,Iŋaliq,Alaska,US,65.7648,-168.911
+AK98,Dot Lake,Kelt’aaddh Menn’,Alaska,US,63.663,-144.049
 AK99,Douglas,,Alaska,US,58.2762,-134.392
 AK100,Dry Creek,,Alaska,US,63.7,-144.567
-AK101,Dutch Harbor,,Alaska,US,53.891000000000005,-166.535
+AK101,Dutch Harbor,,Alaska,US,53.891,-166.535
 AK102,Eagle,,Alaska,US,64.788,-141.2
 AK103,Eagle River,,Alaska,US,61.3221,-149.567
 AK104,Eagle Village,,Alaska,US,64.7805,-141.114
@@ -107,9 +107,9 @@ AK105,Edna Bay,,Alaska,US,55.9489,-133.662
 AK106,Eek,Ekvicuaq,Alaska,US,60.2189,-162.024
 AK107,Egavik,,Alaska,US,64.0332,-160.917
 AK108,Egegik,Igyagiiq,Alaska,US,58.2155,-157.376
-AK109,Egorkovskoi,,Alaska,US,53.56399999999999,-168.0
+AK109,Egorkovskoi,,Alaska,US,53.564,-168.0
 AK110,Eklutna,,Alaska,US,61.458,-149.362
-AK111,Ekuk,,Alaska,US,58.803999999999995,-158.541
+AK111,Ekuk,,Alaska,US,58.804,-158.541
 AK112,Ekwok,Iquaq,Alaska,US,59.3497,-157.475
 AK113,Elephant Point,,Alaska,US,66.2673,-161.333
 AK114,Elfin Cove,,Alaska,US,58.1944,-136.343
@@ -119,20 +119,20 @@ AK117,Emmonak,Imangaq,Alaska,US,62.7778,-164.523
 AK118,English Bay,,Alaska,US,59.3581,-151.922
 AK119,Eska,,Alaska,US,61.7381,-148.906
 AK120,Ester,,Alaska,US,64.8472,-148.014
-AK121,Evansville,,Alaska,US,66.9227,-151.50799999999998
+AK121,Evansville,,Alaska,US,66.9227,-151.508
 AK122,Excursion Inlet,,Alaska,US,58.417,-135.441
 AK123,Eyak,,Alaska,US,60.5652,-145.7
 AK124,Fairbanks,Trothttheet,Alaska,US,64.8378,-147.716
 AK125,False Pass,Isanax̂,Alaska,US,54.8548,-163.407
-AK126,Ferry,,Alaska,US,64.0172,-149.11700000000002
+AK126,Ferry,,Alaska,US,64.0172,-149.117
 AK127,Fish Village,,Alaska,US,62.5212,-163.847
 AK128,Flat,,Alaska,US,62.4536,-158.007
-AK129,Fort Glenn,,Alaska,US,53.3956,-167.88099999999997
+AK129,Fort Glenn,,Alaska,US,53.3956,-167.881
 AK130,Fort Yukon,Gwichyaa Zheh,Alaska,US,66.5647,-145.274
 AK131,Fox,,Alaska,US,64.958,-147.618
-AK132,Gakona,,Alaska,US,62.3019,-145.30200000000002
-AK133,Galena,Notaalee Denh,Alaska,US,64.7333,-156.92700000000002
-AK134,Gambell,Sivuqaq,Alaska,US,63.7797,-171.74099999999999
+AK132,Gakona,,Alaska,US,62.3019,-145.302
+AK133,Galena,Notaalee Denh,Alaska,US,64.7333,-156.927
+AK134,Gambell,Sivuqaq,Alaska,US,63.7797,-171.741
 AK135,Georgetown,,Alaska,US,61.9085,-157.787
 AK136,Girdwood,,Alaska,US,60.9421,-149.167
 AK137,Glennallen,Ciisik’e Na’,Alaska,US,62.1092,-145.546
@@ -148,13 +148,13 @@ AK146,Healy,,Alaska,US,63.8578,-148.966
 AK147,Healy Lake,Mendees Cheeg,Alaska,US,63.9441,-144.755
 AK148,Highland Park,,Alaska,US,64.7582,-147.371
 AK149,Holikachuk,,Alaska,US,62.9112,-159.517
-AK150,Hollis,,Alaska,US,55.4879,-132.66299999999998
-AK151,Holy Cross,,Alaska,US,62.1994,-159.77100000000002
+AK150,Hollis,,Alaska,US,55.4879,-132.663
+AK151,Holy Cross,,Alaska,US,62.1994,-159.771
 AK152,Homer,Tuggeght,Alaska,US,59.6425,-151.548
 AK153,Hoonah,Xunaa / Gaaw Yat’aḵ Aan,Alaska,US,58.11,-135.444
 AK154,Hooper Bay,Naparyaarmiut,Alaska,US,61.5311,-166.097
 AK155,Hope,,Alaska,US,60.9203,-149.64
-AK156,Houston,,Alaska,US,61.6302,-149.81799999999998
+AK156,Houston,,Alaska,US,61.6302,-149.818
 AK157,Hughes,Hut’odlee Kkaakk’et,Alaska,US,66.0488,-154.255
 AK158,Huslia,Ts’aateyhdenaadekk’onh Denh,Alaska,US,65.6986,-156.4
 AK159,Hydaburg,Higdáa G̱ándlaay,Alaska,US,55.208,-132.827
@@ -168,14 +168,14 @@ AK166,Indian,,Alaska,US,60.9881,-149.513
 AK167,Indian River,,Alaska,US,62.6672,-144.433
 AK168,Ingrihak,,Alaska,US,61.7561,-162.0
 AK169,Ivanof Bay,,Alaska,US,55.8996,-159.507
-AK170,Joe Ward Camp,Dzánti K'ihéeni,Alaska,US,66.8673,-143.69899999999998
+AK170,Joe Ward Camp,Dzánti K'ihéeni,Alaska,US,66.8673,-143.699
 AK171,Jonesville,,Alaska,US,61.7311,-148.933
 AK172,Juneau,Dzánti K'ihéeni,Alaska,US,58.3019,-134.42
 AK173,Kachemak,,Alaska,US,59.6488,-151.451
 AK174,Kake,Ḵéex̱ʼ,Alaska,US,56.9758,-133.947
 AK175,Kakhonak,,Alaska,US,59.4421,-154.756
 AK176,Kaktovik,Qaaktuġvik,Alaska,US,70.1319,-143.624
-AK177,Kalifornsky,Unhghenesditnu,Alaska,US,60.4412,-151.19799999999998
+AK177,Kalifornsky,Unhghenesditnu,Alaska,US,60.4412,-151.198
 AK178,Kalskag,,Alaska,US,61.5391,-160.306
 AK179,Kaltag,Ggaał Doh,Alaska,US,64.3272,-158.722
 AK180,Kanakanak,,Alaska,US,59.0031,-158.533
@@ -183,13 +183,13 @@ AK181,Karluk,"Kal’uq, Kal’ut",Alaska,US,57.5719,-154.455
 AK182,Kasaan,Gasa'áan / Kasa'aan,Alaska,US,55.5389,-132.401
 AK183,Kashega,,Alaska,US,53.467,-167.16
 AK184,Kashegelok,,Alaska,US,60.8331,-157.833
-AK185,Kasigluk,Kassigluq,Alaska,US,60.8955,-162.52100000000002
+AK185,Kasigluk,Kassigluq,Alaska,US,60.8955,-162.521
 AK186,Kasilof,Ggasilat,Alaska,US,60.3375,-151.274
 AK187,Kathakne,,Alaska,US,62.9692,-141.832
-AK188,Kenai,,Alaska,US,60.5544,-151.25799999999998
+AK188,Kenai,,Alaska,US,60.5544,-151.258
 AK189,Kenny Lake,,Alaska,US,61.7379,-144.945
-AK190,Kepangalook,,Alaska,US,60.8501,-161.61700000000002
-AK191,Ketchikan,Kichx̱áan,Alaska,US,55.3422,-131.64600000000002
+AK190,Kepangalook,,Alaska,US,60.8501,-161.617
+AK191,Ketchikan,Kichx̱áan,Alaska,US,55.3422,-131.646
 AK192,Kiana,Katyaaq,Alaska,US,66.975,-160.423
 AK193,Kinegnak,,Alaska,US,58.8331,-161.667
 AK194,King Cove,Agdaaĝux̂,Alaska,US,55.0629,-162.31
@@ -201,7 +201,7 @@ AK199,Kiwalik,,Alaska,US,66.0333,-161.833
 AK200,Klawock,Láwaak,Alaska,US,55.5522,-133.096
 AK201,Klery Creek,,Alaska,US,67.1793,-160.4
 AK202,Klukwan,Tlákw.aan,Alaska,US,59.3991,-135.894
-AK203,Knik,,Alaska,US,61.4578,-149.72899999999998
+AK203,Knik,,Alaska,US,61.4578,-149.729
 AK204,Kobuk,Laugviik,Alaska,US,66.9072,-156.881
 AK205,Kodiak,Sun'aq,Alaska,US,57.79,-152.407
 AK206,Kokhanok,Qarr’unaq,Alaska,US,59.4426,-154.761
@@ -219,7 +219,7 @@ AK217,Kwethluk,Kuiggluk,Alaska,US,60.8122,-161.436
 AK218,Kwigillingok,Kuigilnguq,Alaska,US,59.8644,-163.134
 AK219,Kwiguk,Imangaq,Alaska,US,62.7683,-164.5067
 AK220,Lake Minchumina,Menchuh Mene’,Alaska,US,63.8828,-152.312
-AK221,Larsen Bay,Uyaqsaq,Alaska,US,57.54,-153.97899999999998
+AK221,Larsen Bay,Uyaqsaq,Alaska,US,57.54,-153.979
 AK222,Last Tetlin Village,,Alaska,US,63.0332,-142.616
 AK223,Latouche,,Alaska,US,60.0511,-147.9
 AK224,Lemeta,,Alaska,US,64.8582,-147.725
@@ -235,64 +235,64 @@ AK233,Lucky Shot Landing,,Alaska,US,61.7751,-149.408
 AK234,Manley Hot Springs,Too Naaleł Denh,Alaska,US,65.0011,-150.634
 AK235,Manokotak,Manuquutaq,Alaska,US,58.9796,-159.053
 AK236,Mansfield Village,,Alaska,US,63.4672,-143.433
-AK237,Marshall,Masserculleq,Alaska,US,61.8778,-162.08100000000002
+AK237,Marshall,Masserculleq,Alaska,US,61.8778,-162.081
 AK238,Marys Igloo,,Alaska,US,65.1478,-165.063
-AK239,Matanuska,,Alaska,US,61.5421,-149.22899999999998
+AK239,Matanuska,,Alaska,US,61.5421,-149.229
 AK240,McCarthy,,Alaska,US,61.4333,-142.922
 AK241,McGrath,,Alaska,US,62.9564,-155.596
 AK242,McKinley Park Airport,,Alaska,US,63.7331,-148.9111
-AK243,Meakerville,,Alaska,US,60.5421,-145.00799999999998
+AK243,Meakerville,,Alaska,US,60.5421,-145.008
 AK244,Medfra,,Alaska,US,63.1067,-154.714
-AK245,Mekoryuk,Mikuryarmiut / Mikuryar,Alaska,US,60.388000000000005,-166.185
+AK245,Mekoryuk,Mikuryarmiut / Mikuryar,Alaska,US,60.388,-166.185
 AK246,Mendeltna,Bendilna’,Alaska,US,62.0487,-146.5386
 AK247,Mentasta Lake,Mendaesde,Alaska,US,62.9212,-143.792
 AK248,Metlakatla,Maxłakxaała,Alaska,US,55.1292,-131.572
 AK249,Meyers Chuck,,Alaska,US,55.7408,-132.256
 AK250,Minto,,Alaska,US,65.1496,-149.3504
-AK251,Moose Pass,,Alaska,US,60.4876,-149.36700000000002
+AK251,Moose Pass,,Alaska,US,60.4876,-149.367
 AK252,Morzhovoi,,Alaska,US,54.91,-163.303
 AK253,Moses Point,,Alaska,US,64.7002,-162.033
 AK254,Mountain Village,Asaacaryaraq,Alaska,US,62.0884,-163.72
 AK255,Myers Chuck,,Alaska,US,55.742,-132.253
 AK256,Nabesna,Nabaesna’ / Naambia Niign Daacheeg,Alaska,US,62.3719,-143.009
-AK257,Nakeen,,Alaska,US,58.9361,-157.03799999999998
+AK257,Nakeen,,Alaska,US,58.9361,-157.038
 AK258,Naknek,Nakniq,Alaska,US,58.7283,-157.014
 AK259,Nanwalek,,Alaska,US,59.354,-151.916
 AK260,Napaimiut,,Alaska,US,61.5421,-158.692
 AK261,Napakiak,Naparyarraq,Alaska,US,60.6967,-161.952
 AK262,Napamiute,,Alaska,US,61.54,-158.674
 AK263,Napaskiak,Napaskiaq,Alaska,US,60.708,-161.766
-AK264,Nash Harbor,,Alaska,US,60.2041,-166.93900000000002
+AK264,Nash Harbor,,Alaska,US,60.2041,-166.939
 AK265,Nelchina,Xaz Ghae Na’,Alaska,US,61.996,-146.8203
 AK266,Nelson Lagoon,Niilsanam Alĝuudaa,Alaska,US,56.0012,-161.201
 AK267,Nenana,Toghotili,Alaska,US,64.5638,-149.093
 AK268,New Knockhock,,Alaska,US,62.1291,-164.894
 AK269,New Stuyahok,Cetuyaraq,Alaska,US,59.4528,-157.312
-AK270,Newhalen,Nuuriileng,Alaska,US,59.72,-154.89700000000002
-AK271,Newtok,,Alaska,US,60.9427,-164.62900000000002
-AK272,Nightmute,Negtemiut / Negta,Alaska,US,60.4794,-164.72400000000002
+AK270,Newhalen,Nuuriileng,Alaska,US,59.72,-154.897
+AK271,Newtok,,Alaska,US,60.9427,-164.629
+AK272,Nightmute,Negtemiut / Negta,Alaska,US,60.4794,-164.724
 AK273,Nikiski,,Alaska,US,60.6394,-151.334
 AK274,Nikolaevsk,,Alaska,US,59.8109,-151.623
 AK275,Nikolai,Nikolai,Alaska,US,63.0133,-154.375
 AK276,Nikolski,Chalukax̂,Alaska,US,52.938,-168.868
 AK277,Nilikluguk,,Alaska,US,60.6501,-165.15
-AK278,Ninilchik,Niqnalchint Qayeh Kenu,Alaska,US,60.0514,-151.66899999999998
+AK278,Ninilchik,Niqnalchint Qayeh Kenu,Alaska,US,60.0514,-151.669
 AK279,Noatak,Nautaaq,Alaska,US,67.5711,-162.965
-AK280,Nome,Sitŋasuaq,Alaska,US,64.5011,-165.40599999999998
+AK280,Nome,Sitŋasuaq,Alaska,US,64.5011,-165.406
 AK281,Nondalton,Nuvendaltun / Nundaltin,Alaska,US,59.9736,-154.846
 AK282,Noorvik,Nuurvik,Alaska,US,66.8383,-161.033
 AK283,North Pole,,Alaska,US,64.7511,-147.349
 AK284,Northway,K’ehtthiign,Alaska,US,62.9616,-141.937
-AK285,Northway Indian Village,,Alaska,US,62.9832,-141.94899999999998
+AK285,Northway Indian Village,,Alaska,US,62.9832,-141.949
 AK286,Northway Junction,,Alaska,US,63.0173,-141.792
 AK287,Nuiqsut,Nuiqsat,Alaska,US,70.2175,-150.976
-AK288,Nulato,Noolaaghe Doh,Alaska,US,64.7194,-158.10299999999998
-AK289,Nunam Iqua,Sheldon Point,Alaska,US,62.5336,-164.84099999999998
+AK288,Nulato,Noolaaghe Doh,Alaska,US,64.7194,-158.103
+AK289,Nunam Iqua,Sheldon Point,Alaska,US,62.5336,-164.841
 AK290,Nunapitchuk,Nunapicuar,Alaska,US,60.8969,-162.459
 AK291,Nyac,,Alaska,US,61.0061,-159.946
 AK292,Ohogamiut,,Alaska,US,61.5677,-161.864
 AK293,Old Harbor,Nuniaq,Alaska,US,57.2028,-153.304
-AK294,Old Minto,,Alaska,US,64.8882,-149.18200000000002
+AK294,Old Minto,,Alaska,US,64.8882,-149.182
 AK295,Ophir,,Alaska,US,63.1447,-156.519
 AK296,Oscarville,Kuiggayagaq,Alaska,US,60.7273,-161.79
 AK297,Osviak,,Alaska,US,58.8171,-161.3
@@ -302,21 +302,21 @@ AK300,Palmer,,Alaska,US,61.5997,-149.113
 AK301,Pastolik,,Alaska,US,62.9972,-163.304
 AK302,Pauloff Harbor,,Alaska,US,54.4589,-162.7
 AK303,Paxson,,Alaska,US,63.033,-145.4979
-AK304,Pedro Bay,,Alaska,US,59.7914,-154.09799999999998
+AK304,Pedro Bay,,Alaska,US,59.7914,-154.098
 AK305,Pelican,K'udeis'x̱'e,Alaska,US,57.9608,-136.227
 AK306,Pennock Island,,Alaska,US,55.328,-131.628
 AK307,Perryville,Perry-q,Alaska,US,55.9119,-159.166
 AK308,Petersburg,Séet Ká,Alaska,US,56.8125,-132.955
-AK309,Petersville,,Alaska,US,62.373000000000005,-150.7332
+AK309,Petersville,,Alaska,US,62.373,-150.7332
 AK310,Pile Bay Village,,Alaska,US,59.7789,-153.8819
 AK311,Pilot Point,Agisaq,Alaska,US,57.5641,-157.579
 AK312,Pilot Station,Tuutalgaq,Alaska,US,61.9389,-162.875
-AK313,Pitkas Point,Negeqliim Painga,Alaska,US,62.0328,-163.28799999999998
-AK314,Platinum,Arviq,Alaska,US,59.013000000000005,-161.816
+AK313,Pitkas Point,Negeqliim Painga,Alaska,US,62.0328,-163.288
+AK314,Platinum,Arviq,Alaska,US,59.013,-161.816
 AK315,Point Baker,,Alaska,US,56.3528,-133.621
 AK316,Point Hope,Tikiġaq,Alaska,US,68.3477,-166.808
-AK317,Point Lay,Kali,Alaska,US,69.7574,-163.05100000000002
-AK318,Poorman,,Alaska,US,64.0991,-155.54399999999998
+AK317,Point Lay,Kali,Alaska,US,69.7574,-163.051
+AK318,Poorman,,Alaska,US,64.0991,-155.544
 AK319,Port Alexander,,Alaska,US,56.2497,-134.644
 AK320,Port Alsworth,,Alaska,US,60.2025,-154.313
 AK321,Port Ashton,Xunaa / Gaaw Yat’aḵ Aan,Alaska,US,60.0581,-148.05
@@ -326,7 +326,7 @@ AK324,Port Lions,Masiqsirraq,Alaska,US,57.8675,-152.882
 AK325,Port Mackenzie,,Alaska,US,61.2686,-149.9202
 AK326,Port Moller,,Alaska,US,55.99,-160.577
 AK327,Port Protection,,Alaska,US,56.3127,-133.602
-AK328,Portage,,Alaska,US,60.8381,-148.97899999999998
+AK328,Portage,,Alaska,US,60.8381,-148.979
 AK329,Portage Creek,,Alaska,US,58.9006,-157.714
 AK330,Portlock,,Alaska,US,59.2144,-151.7461
 AK331,Prudhoe Bay,Sagavanirktok,Alaska,US,70.2366,-148.38
@@ -338,15 +338,15 @@ AK336,Refuge Cove,,Alaska,US,55.407,-131.741
 AK337,Ruby,Tl'aa'ologhe,Alaska,US,64.7394,-155.487
 AK338,Russian Mission,Iqugmiut,Alaska,US,61.7856,-161.325
 AK339,Saint George,Anĝaaxchalux̂,Alaska,US,56.603,-169.545
-AK340,Saint Mary's,Negeqliq,Alaska,US,62.053000000000004,-163.166
+AK340,Saint Mary's,Negeqliq,Alaska,US,62.053,-163.166
 AK341,Saint Michael,Taciq,Alaska,US,63.478,-162.039
-AK342,Saint Paul,,Alaska,US,57.1221,-170.27599999999998
+AK342,Saint Paul,,Alaska,US,57.1221,-170.276
 AK343,Salamatof,Ken Dech’etl’t,Alaska,US,60.5878,-151.326
 AK344,Salcha,"Soł Chaget, Saagescheeg",Alaska,US,64.5288,-146.899
-AK345,Salt Chuck,,Alaska,US,55.628,-132.55200000000002
+AK345,Salt Chuck,,Alaska,US,55.628,-132.552
 AK346,Sanak,,Alaska,US,54.4831,-162.814
 AK347,Sand Point,,Alaska,US,55.3397,-160.497
-AK348,Savonoski,,Alaska,US,58.7171,-156.86700000000002
+AK348,Savonoski,,Alaska,US,58.7171,-156.867
 AK349,Savoonga,Sivungaq,Alaska,US,63.6904,-170.481
 AK350,Saxman,,Alaska,US,55.3183,-131.596
 AK351,Scammon Bay,Marayaarmiut,Alaska,US,61.8428,-165.582
@@ -358,20 +358,20 @@ AK356,Shaktoolik,Saktuliq,Alaska,US,64.35,-161.183
 AK357,Shemya Station,,Alaska,US,52.7246,174.112
 AK358,Shishmaref,Qigiqtaq,Alaska,US,66.2567,-166.072
 AK359,Shungnak,Isiŋnaq / Nuurviuraq,Alaska,US,66.888,-157.136
-AK360,Sitka,Sheet'ká,Alaska,US,57.053000000000004,-135.33
+AK360,Sitka,Sheet'ká,Alaska,US,57.053,-135.33
 AK361,Skagway,,Alaska,US,59.4583,-135.314
 AK362,Skwentna,,Alaska,US,61.9649,-151.158
 AK363,Slana,Stl’ana’,Alaska,US,62.707,-143.9697
 AK364,Slaterville,,Alaska,US,64.8532,-147.717
 AK365,Sleetmute,Cellitemiut,Alaska,US,61.7025,-157.17
 AK366,Soldotna,,Alaska,US,60.4878,-151.058
-AK367,Solomon,Aaŋuutaq,Alaska,US,64.5608,-164.43900000000002
+AK367,Solomon,Aaŋuutaq,Alaska,US,64.5608,-164.439
 AK368,South Naknek,Qinuyang,Alaska,US,58.7155,-156.998
 AK369,Spenard,,Alaska,US,61.1881,-149.917
 AK370,Squaw Harbor,,Alaska,US,55.2433,-160.553
 AK371,St. Mary's,Negeqliq,Alaska,US,62.0331,-163.25
-AK372,Stebbins,Tapraq,Alaska,US,63.5222,-162.28799999999998
-AK373,Sterling,,Alaska,US,60.5381,-150.75799999999998
+AK372,Stebbins,Tapraq,Alaska,US,63.5222,-162.288
+AK373,Sterling,,Alaska,US,60.5381,-150.758
 AK374,Stevens Village,Denyeet,Alaska,US,66.0063,-149.091
 AK375,Stony River,Gidighuyghatno’ Xidochagg Qay / K'qizaghetnu,Alaska,US,61.7831,-156.588
 AK376,Summit,,Alaska,US,63.3292,-149.119
@@ -383,7 +383,7 @@ AK381,Takotna,Tochotno’,Alaska,US,62.9886,-156.064
 AK382,Talkeetna,K'dalkitnu,Alaska,US,62.3239,-150.109
 AK383,Tanacross,Taats’altęy,Alaska,US,63.378,-143.356
 AK384,Tanana,Hohudodetlaatl Denh,Alaska,US,65.1719,-152.079
-AK385,Tanunak,Tununeq,Alaska,US,60.5851,-165.25599999999997
+AK385,Tanunak,Tununeq,Alaska,US,60.5851,-165.256
 AK386,Tatitlek,Taatiilaaq,Alaska,US,60.8647,-146.679
 AK387,Tazlina,Tezdlen Na’,Alaska,US,62.0305,-145.416
 AK388,Tee Harbor,,Alaska,US,58.41,-134.757
@@ -393,36 +393,36 @@ AK391,Teller Mission,Tala,Alaska,US,65.3332,-166.484
 AK392,Tenakee Springs,Tʼanag̱eey / Tlaagoowu Aan,Alaska,US,57.7808,-135.219
 AK393,Tetlin,Teełąy,Alaska,US,63.1373,-142.5208
 AK394,Tetlin Junction,,Alaska,US,63.3172,-142.599
-AK395,Thane,,Alaska,US,58.263999999999996,-134.328
+AK395,Thane,,Alaska,US,58.264,-134.328
 AK396,Thorne Bay,,Alaska,US,55.7274,-132.471
 AK397,Tin City,,Alaska,US,65.5502,-167.851
 AK398,Togiak,Tuyuryaq,Alaska,US,59.0619,-160.376
 AK399,Tok,,Alaska,US,63.3366,-142.985
-AK400,Tokeen,,Alaska,US,55.938,-133.32399999999998
+AK400,Tokeen,,Alaska,US,55.938,-133.324
 AK401,Toksook Bay,"Nunakauyaq, Tuqsuq/Tuqsuk",Alaska,US,60.5303,-165.102
-AK402,Tolovana,,Alaska,US,64.8542,-149.82399999999998
+AK402,Tolovana,,Alaska,US,64.8542,-149.824
 AK403,Tonsina,,Alaska,US,61.6558,-145.175
-AK404,Tuluksak,Tuulkessaaq,Alaska,US,61.1025,-160.96200000000002
-AK405,Tuntutuliak,Tuntutuliaq,Alaska,US,60.3397,-162.66899999999998
-AK406,Tununak,Tununeq,Alaska,US,60.5855,-165.25599999999997
+AK404,Tuluksak,Tuulkessaaq,Alaska,US,61.1025,-160.962
+AK405,Tuntutuliak,Tuntutuliaq,Alaska,US,60.3397,-162.669
+AK406,Tununak,Tununeq,Alaska,US,60.5855,-165.256
 AK407,Twin Hills,Ingricuar,Alaska,US,59.0792,-160.275
 AK408,Tyonek,Qaggeyshlat,Alaska,US,61.0681,-151.137
-AK409,Ugashik,Ugaasaq,Alaska,US,57.513000000000005,-157.39700000000002
-AK410,Ukivok,,Alaska,US,64.9672,-168.06799999999998
-AK411,Umiat,,Alaska,US,69.3674,-152.13299999999998
+AK409,Ugashik,Ugaasaq,Alaska,US,57.513,-157.397
+AK410,Ukivok,,Alaska,US,64.9672,-168.068
+AK411,Umiat,,Alaska,US,69.3674,-152.133
 AK412,Umkumiute,,Alaska,US,60.4983,-165.199
-AK413,Umnak,,Alaska,US,53.266999999999996,-168.217
-AK414,Unalakleet,Uŋalaqłiq,Alaska,US,63.873000000000005,-160.78799999999998
+AK413,Umnak,,Alaska,US,53.267,-168.217
+AK414,Unalakleet,Uŋalaqłiq,Alaska,US,63.873,-160.788
 AK415,Unalaska,Iluulux̂,Alaska,US,53.8733,-166.533
 AK416,Unga,,Alaska,US,55.1828,-160.506
 AK417,Upper Kalskag,,Alaska,US,61.5372,-160.305
 AK418,Utqiaġvik,Barrow,Alaska,US,71.2905,-156.789
 AK419,Utukakarvik,,Alaska,US,61.9611,-164.75
 AK420,Uyak,,Alaska,US,57.6256,-153.988
-AK421,Valdez,Suacit,Alaska,US,61.1308,-146.34799999999998
-AK422,Venetie,Vįįhtąįį,Alaska,US,67.0139,-146.41899999999998
-AK423,Wainwright,Ulġuniq,Alaska,US,70.6369,-160.03799999999998
-AK424,Wales,Kiŋigin,Alaska,US,65.60969,-168.0876
+AK421,Valdez,Suacit,Alaska,US,61.1308,-146.348
+AK422,Venetie,Vįįhtąįį,Alaska,US,67.0139,-146.419
+AK423,Wainwright,Ulġuniq,Alaska,US,70.6369,-160.038
+AK424,Wales,Kiŋigin,Alaska,US,65.6097,-168.0876
 AK425,Ward Cove,,Alaska,US,55.408,-131.724
 AK426,Wasilla,,Alaska,US,61.5814,-149.439
 AK427,Whale Pass,,Alaska,US,56.1,-133.167

--- a/vector_data/point/alberta_point_locations.csv
+++ b/vector_data/point/alberta_point_locations.csv
@@ -3,85 +3,85 @@ AB1,Abee,,Alberta,CA,54.238,-113.025
 AB2,Acadia Valley,,Alberta,CA,51.1585,-110.209
 AB3,Acme,,Alberta,CA,51.4972,-113.509
 AB4,Aetna,,Alberta,CA,49.1339,-113.24
-AB5,Airdrie,,Alberta,CA,51.2814,-114.00399999999999
+AB5,Airdrie,,Alberta,CA,51.2814,-114.004
 AB6,Alberta Beach,,Alberta,CA,53.6756,-114.353
-AB7,Alder Flats,,Alberta,CA,52.9331,-114.95700000000001
-AB8,Aldersyde,,Alberta,CA,50.6761,-113.87899999999999
+AB7,Alder Flats,,Alberta,CA,52.9331,-114.957
+AB8,Aldersyde,,Alberta,CA,50.6761,-113.879
 AB9,Alexander,,Alberta,CA,53.8033,-113.919
 AB10,Alexis,,Alberta,CA,53.7324,-114.491
-AB11,Alhambra,,Alberta,CA,52.3431,-114.67200000000001
+AB11,Alhambra,,Alberta,CA,52.3431,-114.672
 AB12,Alix,,Alberta,CA,52.3981,-113.189
 AB13,Alliance,,Alberta,CA,52.4344,-111.785
 AB14,Altario,,Alberta,CA,51.9186,-110.162
-AB15,Amesbury,,Alberta,CA,55.0811,-112.49700000000001
+AB15,Amesbury,,Alberta,CA,55.0811,-112.497
 AB16,Amisk,,Alberta,CA,52.5656,-111.057
 AB17,Andrew,,Alberta,CA,53.8783,-112.335
 AB18,Anzac,,Alberta,CA,56.4478,-111.046
 AB19,Arcadia,,Alberta,CA,55.4026,-116.131
-AB20,Ardenode,,Alberta,CA,51.1444,-113.42399999999999
-AB21,Ardley,,Alberta,CA,52.2611,-113.23200000000001
+AB20,Ardenode,,Alberta,CA,51.1444,-113.424
+AB21,Ardley,,Alberta,CA,52.2611,-113.232
 AB22,Ardmore,,Alberta,CA,54.3314,-110.477
-AB23,Ardrossan,,Alberta,CA,53.5522,-113.14399999999999
+AB23,Ardrossan,,Alberta,CA,53.5522,-113.144
 AB24,Argentia Beach,,Alberta,CA,53.0536,-114.016
-AB25,Armada,,Alberta,CA,50.4139,-112.75399999999999
+AB25,Armada,,Alberta,CA,50.4139,-112.754
 AB26,Armena,,Alberta,CA,53.1225,-112.949
 AB27,Arrowwood,,Alberta,CA,50.7392,-113.15
 AB28,Artists View Park West,,Alberta,CA,51.0788,-114.272
 AB29,Ashmont,,Alberta,CA,54.1292,-111.568
-AB30,Assumption,,Alberta,CA,58.6994,-118.68700000000001
-AB31,Athabasca,,Alberta,CA,54.7151,-113.28399999999999
-AB32,Atikameg,,Alberta,CA,55.9169,-115.65100000000001
+AB30,Assumption,,Alberta,CA,58.6994,-118.687
+AB31,Athabasca,,Alberta,CA,54.7151,-113.284
+AB32,Atikameg,,Alberta,CA,55.9169,-115.651
 AB33,Atmore,,Alberta,CA,54.8192,-112.55
 AB34,Balmoral,,Alberta,CA,52.2754,-113.7
-AB35,Banff,,Alberta,CA,51.178999999999995,-115.569
-AB36,Barnwell,,Alberta,CA,49.7606,-112.26299999999999
+AB35,Banff,,Alberta,CA,51.179,-115.569
+AB36,Barnwell,,Alberta,CA,49.7606,-112.263
 AB37,Barons,,Alberta,CA,49.9975,-113.081
 AB38,Barrhead,,Alberta,CA,54.1217,-114.404
 AB39,Bashaw,,Alberta,CA,52.5831,-112.97
-AB40,Bassano,,Alberta,CA,50.7875,-112.46799999999999
-AB41,Bawlf,,Alberta,CA,52.9194,-112.46600000000001
+AB40,Bassano,,Alberta,CA,50.7875,-112.468
+AB41,Bawlf,,Alberta,CA,52.9194,-112.466
 AB42,Bay Tree,,Alberta,CA,55.825,-119.906
 AB43,Beaumont,,Alberta,CA,53.3525,-113.415
-AB44,Beauvallon,,Alberta,CA,53.6592,-111.36200000000001
+AB44,Beauvallon,,Alberta,CA,53.6592,-111.362
 AB45,Beaver,,Alberta,CA,58.4708,-116.584
 AB46,Beaver Lake,,Alberta,CA,54.753,-111.927
-AB47,Beaver Lake,,Alberta,CA,54.6687,-111.90700000000001
+AB47,Beaver Lake,,Alberta,CA,54.6687,-111.907
 AB48,Beaver Mines,,Alberta,CA,49.4567,-114.197
-AB49,Beaverlodge,,Alberta,CA,55.2118,-119.42200000000001
+AB49,Beaverlodge,,Alberta,CA,55.2118,-119.422
 AB50,Beiseker,,Alberta,CA,51.385,-113.536
 AB51,Bellevue,,Alberta,CA,49.5808,-114.366
 AB52,Bellis,,Alberta,CA,54.1428,-112.15
-AB53,Benalto,,Alberta,CA,52.3078,-114.27799999999999
+AB53,Benalto,,Alberta,CA,52.3078,-114.278
 AB54,Benchlands,,Alberta,CA,51.2834,-114.801
 AB55,Bentley,,Alberta,CA,52.4664,-114.051
 AB56,Bergen,,Alberta,CA,51.7081,-114.632
-AB57,Berwyn,,Alberta,CA,56.1488,-117.72399999999999
+AB57,Berwyn,,Alberta,CA,56.1488,-117.724
 AB58,Betula Beach,,Alberta,CA,53.5362,-114.677
 AB59,Bezanson,,Alberta,CA,55.2286,-118.361
-AB60,Big Valley,,Alberta,CA,52.0328,-112.75200000000001
-AB61,Bigstone,,Alberta,CA,55.9436,-113.76899999999999
+AB60,Big Valley,,Alberta,CA,52.0328,-112.752
+AB61,Bigstone,,Alberta,CA,55.9436,-113.769
 AB62,Bindloss,,Alberta,CA,50.88,-110.274
-AB63,Birch Cove,,Alberta,CA,53.9538,-114.37200000000001
+AB63,Birch Cove,,Alberta,CA,53.9538,-114.372
 AB64,Bircham,,Alberta,CA,51.4589,-113.431
 AB65,Birchcliff,,Alberta,CA,52.3619,-114.118
 AB66,Bittern Lake,,Alberta,CA,53.0081,-113.057
 AB67,Black Diamond,,Alberta,CA,50.6881,-114.234
 AB68,Blackfalds,,Alberta,CA,52.3783,-113.796
-AB69,Blackfoot,,Alberta,CA,53.2892,-110.17299999999999
-AB70,Blackie,,Alberta,CA,50.6044,-113.62299999999999
+AB69,Blackfoot,,Alberta,CA,53.2892,-110.173
+AB70,Blackie,,Alberta,CA,50.6044,-113.623
 AB71,Blairmore,,Alberta,CA,49.6081,-114.443
-AB72,Blue Ridge,,Alberta,CA,54.125,-115.37799999999999
+AB72,Blue Ridge,,Alberta,CA,54.125,-115.378
 AB73,Blueberry Mountain,,Alberta,CA,55.9267,-119.15
-AB74,Bluesky,,Alberta,CA,56.0735,-118.23899999999999
+AB74,Bluesky,,Alberta,CA,56.0735,-118.239
 AB75,Bluffton,,Alberta,CA,52.7494,-114.292
 AB76,Bodo,,Alberta,CA,52.1533,-110.079
 AB77,Bon Accord,,Alberta,CA,53.8369,-113.412
-AB78,Bonanza,,Alberta,CA,55.9128,-119.82700000000001
+AB78,Bonanza,,Alberta,CA,55.9128,-119.827
 AB79,Bondiss,,Alberta,CA,54.5981,-112.695
-AB80,Bonnyville,,Alberta,CA,54.2672,-110.73899999999999
+AB80,Bonnyville,,Alberta,CA,54.2672,-110.739
 AB81,Botha,,Alberta,CA,52.3081,-112.524
-AB82,Bow Island,,Alberta,CA,49.8672,-111.37899999999999
-AB83,Bowden,,Alberta,CA,51.9332,-114.03200000000001
+AB82,Bow Island,,Alberta,CA,49.8672,-111.379
+AB83,Bowden,,Alberta,CA,51.9332,-114.032
 AB84,Boyle,,Alberta,CA,54.5897,-112.807
 AB85,Bragg Creek,,Alberta,CA,50.9503,-114.57
 AB86,Brant,,Alberta,CA,50.5169,-113.512
@@ -90,20 +90,20 @@ AB88,Breynat,,Alberta,CA,55.1414,-112.491
 AB89,Bristol Oakes,,Alberta,CA,53.6824,-113.564
 AB90,Brocket,,Alberta,CA,49.5467,-113.75
 AB91,Brooks,,Alberta,CA,50.5672,-111.895
-AB92,Brownfield,,Alberta,CA,52.3172,-111.43299999999999
+AB92,Brownfield,,Alberta,CA,52.3172,-111.433
 AB93,Brownvale,,Alberta,CA,56.1282,-117.896
 AB94,Bruce,,Alberta,CA,53.1739,-112.039
 AB95,Bruderheim,,Alberta,CA,53.7997,-112.928
 AB96,Brule,,Alberta,CA,53.284,-117.874
 AB97,Buck Creek,,Alberta,CA,53.1039,-114.896
 AB98,Buck Lake,,Alberta,CA,52.9486,-114.777
-AB99,Buffalo Head Prairie,,Alberta,CA,58.0508,-116.34899999999999
+AB99,Buffalo Head Prairie,,Alberta,CA,58.0508,-116.349
 AB100,Buffalo Lake Metis Settlement,,Alberta,CA,54.5791,-112.448
 AB101,Buford,,Alberta,CA,53.2471,-113.927
 AB102,Bulwark,,Alberta,CA,52.2417,-111.587
 AB103,Burdett,,Alberta,CA,49.835,-111.523
 AB104,Burmis,,Alberta,CA,49.5572,-114.288
-AB105,Burnstick Lake,,Alberta,CA,51.9894,-114.89200000000001
+AB105,Burnstick Lake,,Alberta,CA,51.9894,-114.892
 AB106,Busby,,Alberta,CA,53.9481,-113.891
 AB107,Byemoor,,Alberta,CA,51.9797,-112.287
 AB108,Cadogan,,Alberta,CA,52.3192,-110.449
@@ -118,20 +118,20 @@ AB116,Cambria,,Alberta,CA,51.3939,-112.59
 AB117,Campsie,,Alberta,CA,54.1278,-114.647
 AB118,Camrose,,Alberta,CA,53.0181,-112.839
 AB119,Canmore,,Alberta,CA,51.0928,-115.361
-AB120,Canyon Creek,,Alberta,CA,55.3666,-115.09700000000001
+AB120,Canyon Creek,,Alberta,CA,55.3666,-115.097
 AB121,Canyon Heights,,Alberta,CA,52.2907,-113.704
-AB122,Carbon,,Alberta,CA,51.4858,-113.15100000000001
+AB122,Carbon,,Alberta,CA,51.4858,-113.151
 AB123,Carbondale,,Alberta,CA,53.7464,-113.527
 AB124,Cardiff,,Alberta,CA,53.7728,-113.6
 AB125,Cardston,,Alberta,CA,49.1962,-113.307
 AB126,Carmangay,,Alberta,CA,50.1294,-113.111
 AB127,Caroline,,Alberta,CA,52.0948,-114.738
 AB128,Carseland,,Alberta,CA,50.8544,-113.471
-AB129,Carstairs,,Alberta,CA,51.5656,-114.09899999999999
+AB129,Carstairs,,Alberta,CA,51.5656,-114.099
 AB130,Caslan,,Alberta,CA,54.6311,-112.512
 AB131,Cassils,,Alberta,CA,50.5769,-112.046
 AB132,Castor,,Alberta,CA,52.2192,-111.904
-AB133,Cayley,,Alberta,CA,50.4481,-113.84700000000001
+AB133,Cayley,,Alberta,CA,50.4481,-113.847
 AB134,Central Park,,Alberta,CA,52.3309,-113.823
 AB135,Cereal,,Alberta,CA,51.4183,-110.8
 AB136,Cessford,,Alberta,CA,51.0064,-111.557
@@ -141,12 +141,12 @@ AB139,Chauvin,,Alberta,CA,52.6936,-110.141
 AB140,Cheadle,,Alberta,CA,51.0144,-113.541
 AB141,Cherhill,,Alberta,CA,53.8192,-114.677
 AB142,Cherry Grove,,Alberta,CA,54.3561,-110.075
-AB143,Chestermere,,Alberta,CA,51.0373,-113.82799999999999
+AB143,Chestermere,,Alberta,CA,51.0373,-113.828
 AB144,Chin,,Alberta,CA,49.7635,-112.445
 AB145,Chinook,,Alberta,CA,51.4494,-110.925
 AB146,Chipewyan Lake,,Alberta,CA,56.9403,-113.473
-AB147,Chipewyan Prairie,,Alberta,CA,55.9358,-110.71700000000001
-AB148,Chipman,,Alberta,CA,53.6983,-112.63799999999999
+AB147,Chipewyan Prairie,,Alberta,CA,55.9358,-110.717
+AB148,Chipman,,Alberta,CA,53.6983,-112.638
 AB149,Chisholm,,Alberta,CA,54.9094,-114.169
 AB150,Chokio,,Alberta,CA,49.5819,-113.66
 AB151,Clairmont,,Alberta,CA,55.2614,-118.794
@@ -156,39 +156,39 @@ AB154,Cleardale,,Alberta,CA,56.3558,-119.478
 AB155,Clearwater Estates,,Alberta,CA,53.5694,-114.081
 AB156,Clive,,Alberta,CA,52.4774,-113.445
 AB157,Cluny,,Alberta,CA,50.8411,-112.869
-AB158,Clyde,,Alberta,CA,54.1502,-113.63600000000001
+AB158,Clyde,,Alberta,CA,54.1502,-113.636
 AB159,Coaldale,,Alberta,CA,49.7278,-112.619
 AB160,Coalhurst,,Alberta,CA,49.7467,-112.931
 AB161,Cochrane,,Alberta,CA,51.1897,-114.484
-AB162,Cochrane Lake,,Alberta,CA,51.2434,-114.48200000000001
-AB163,Cold Lake,,Alberta,CA,54.4664,-110.18799999999999
-AB164,Coleman,,Alberta,CA,49.6353,-114.50299999999999
-AB165,Colinton,,Alberta,CA,54.6206,-113.25299999999999
-AB166,College Heights,,Alberta,CA,52.4892,-113.73299999999999
+AB162,Cochrane Lake,,Alberta,CA,51.2434,-114.482
+AB163,Cold Lake,,Alberta,CA,54.4664,-110.188
+AB164,Coleman,,Alberta,CA,49.6353,-114.503
+AB165,Colinton,,Alberta,CA,54.6206,-113.253
+AB166,College Heights,,Alberta,CA,52.4892,-113.733
 AB167,Collingwood Cove,,Alberta,CA,53.4469,-113.005
-AB168,Compeer,,Alberta,CA,51.8594,-110.01299999999999
+AB168,Compeer,,Alberta,CA,51.8594,-110.013
 AB169,Condor,,Alberta,CA,52.3264,-114.555
 AB170,Conklin,,Alberta,CA,55.6308,-111.09
 AB171,Connemara,,Alberta,CA,50.4001,-113.829
 AB172,Conrich,,Alberta,CA,51.0933,-113.863
 AB173,Consort,,Alberta,CA,52.0123,-110.771
-AB174,Cooking Lake,,Alberta,CA,53.4114,-113.12200000000001
+AB174,Cooking Lake,,Alberta,CA,53.4114,-113.122
 AB175,Coronado,,Alberta,CA,53.8878,-113.295
 AB176,Coronation,,Alberta,CA,52.0947,-111.448
 AB177,Coutts,,Alberta,CA,49.0028,-111.959
-AB178,Cowley,,Alberta,CA,49.568000000000005,-114.074
+AB178,Cowley,,Alberta,CA,49.568,-114.074
 AB179,Craigmyle,,Alberta,CA,51.6697,-112.243
 AB180,Cremona,,Alberta,CA,51.5453,-114.485
 AB181,Crossfield,,Alberta,CA,51.4306,-114.031
-AB182,Crystal Meadows,,Alberta,CA,53.5634,-114.16799999999999
+AB182,Crystal Meadows,,Alberta,CA,53.5634,-114.168
 AB183,Crystal Springs,,Alberta,CA,52.9733,-114.041
-AB184,Czar,,Alberta,CA,52.4547,-110.82799999999999
+AB184,Czar,,Alberta,CA,52.4547,-110.828
 AB185,Dalemead,,Alberta,CA,50.8747,-113.637
 AB186,Dalroy,,Alberta,CA,51.1286,-113.669
 AB187,Dapp,,Alberta,CA,54.345,-113.916
 AB188,Dawn Valley,,Alberta,CA,53.6214,-114.02
 AB189,Daysland,,Alberta,CA,52.8673,-112.264
-AB190,De Winton,,Alberta,CA,50.8231,-114.01899999999999
+AB190,De Winton,,Alberta,CA,50.8231,-114.019
 AB191,Deadwood,,Alberta,CA,56.7411,-117.458
 AB192,DeBolt,,Alberta,CA,55.2217,-118.02
 AB193,Del Bonita,,Alberta,CA,49.0294,-112.791
@@ -196,19 +196,19 @@ AB194,Delburne,,Alberta,CA,52.1981,-113.235
 AB195,Delia,,Alberta,CA,51.6306,-112.374
 AB196,Dene Tha',,Alberta,CA,58.5149,-117.065
 AB197,Denwood,,Alberta,CA,52.8176,-110.891
-AB198,Derwent,,Alberta,CA,53.6545,-110.96700000000001
+AB198,Derwent,,Alberta,CA,53.6545,-110.967
 AB199,Devon,,Alberta,CA,53.3613,-113.725
 AB200,Devonshire Meadows,,Alberta,CA,53.3888,-113.83
 AB201,Dewberry,,Alberta,CA,53.5881,-110.525
 AB202,Diamond City,,Alberta,CA,49.7956,-112.839
-AB203,Dickson,,Alberta,CA,52.0581,-114.30799999999999
+AB203,Dickson,,Alberta,CA,52.0581,-114.308
 AB204,Didsbury,,Alberta,CA,51.6594,-114.137
-AB205,Dixonville,,Alberta,CA,56.5374,-117.67200000000001
+AB205,Dixonville,,Alberta,CA,56.5374,-117.672
 AB206,Dogpound,,Alberta,CA,51.4567,-114.397
 AB207,Donalda,,Alberta,CA,52.5836,-112.574
 AB208,Donnelly,,Alberta,CA,55.7289,-117.105
 AB209,Dorothy,,Alberta,CA,51.2792,-112.325
-AB210,Drayton Valley,,Alberta,CA,53.2215,-114.97399999999999
+AB210,Drayton Valley,,Alberta,CA,53.2215,-114.974
 AB211,Driftpile,,Alberta,CA,55.3428,-115.788
 AB212,Drumheller,,Alberta,CA,51.4644,-112.719
 AB213,Duchess,,Alberta,CA,50.7311,-111.906
@@ -217,9 +217,9 @@ AB215,Duhamel,,Alberta,CA,52.9156,-112.963
 AB216,Duncan's,,Alberta,CA,56.1208,-117.861
 AB217,Dunmore,,Alberta,CA,49.9703,-110.584
 AB218,Durward,,Alberta,CA,50.2956,-113.713
-AB219,Duvernay,,Alberta,CA,53.7861,-111.69200000000001
+AB219,Duvernay,,Alberta,CA,53.7861,-111.692
 AB220,Eaglesham,,Alberta,CA,55.7825,-117.883
-AB221,East Coulee,,Alberta,CA,51.3436,-112.49799999999999
+AB221,East Coulee,,Alberta,CA,51.3436,-112.498
 AB222,East Prairie Metis Settlement,,Alberta,CA,55.1891,-116.27
 AB223,Eastview Acres,,Alberta,CA,49.7895,-113.016
 AB224,Eckville,,Alberta,CA,52.36,-114.367
@@ -229,36 +229,36 @@ AB227,Edmonton,,Alberta,CA,53.5358,-113.494
 AB228,Edson,,Alberta,CA,53.5866,-116.436
 AB229,Egremont,,Alberta,CA,54.0383,-113.126
 AB230,Eldoes Trailer Park,,Alberta,CA,55.1696,-118.744
-AB231,Elizabeth Metis Settlement,,Alberta,CA,54.217,-110.09200000000001
-AB232,Elk Point,,Alberta,CA,53.9011,-110.90100000000001
-AB233,Elkwater,,Alberta,CA,49.6608,-110.28200000000001
-AB234,Ellscott,,Alberta,CA,54.5031,-112.90100000000001
+AB231,Elizabeth Metis Settlement,,Alberta,CA,54.217,-110.092
+AB232,Elk Point,,Alberta,CA,53.9011,-110.901
+AB233,Elkwater,,Alberta,CA,49.6608,-110.282
+AB234,Ellscott,,Alberta,CA,54.5031,-112.901
 AB235,Elmworth,,Alberta,CA,55.0539,-119.616
-AB236,Elnora,,Alberta,CA,51.9936,-113.20100000000001
+AB236,Elnora,,Alberta,CA,51.9936,-113.201
 AB237,Empress,,Alberta,CA,50.9543,-110.008
-AB238,Enchant,,Alberta,CA,50.17,-112.42200000000001
-AB239,Endiang,,Alberta,CA,51.9539,-112.15799999999999
+AB238,Enchant,,Alberta,CA,50.17,-112.422
+AB239,Endiang,,Alberta,CA,51.9539,-112.158
 AB240,Enilda,,Alberta,CA,55.4169,-116.311
-AB241,Enoch,,Alberta,CA,53.4997,-113.76100000000001
+AB241,Enoch,,Alberta,CA,53.4997,-113.761
 AB242,Ensign,,Alberta,CA,50.475,-113.432
 AB243,Entrance,,Alberta,CA,53.3748,-117.684
-AB244,Entwistle,,Alberta,CA,53.5944,-114.99600000000001
-AB245,Ermineskin,,Alberta,CA,52.836000000000006,-113.454
+AB244,Entwistle,,Alberta,CA,53.5944,-114.996
+AB245,Ermineskin,,Alberta,CA,52.836,-113.454
 AB246,Erskine,,Alberta,CA,52.3211,-112.88
-AB247,Etzikom,,Alberta,CA,49.4769,-111.10700000000001
-AB248,Evansburg,,Alberta,CA,53.6004,-115.01700000000001
-AB249,Exshaw,,Alberta,CA,51.0635,-115.15899999999999
+AB247,Etzikom,,Alberta,CA,49.4769,-111.107
+AB248,Evansburg,,Alberta,CA,53.6004,-115.017
+AB249,Exshaw,,Alberta,CA,51.0635,-115.159
 AB250,Fabyan,,Alberta,CA,52.8819,-110.994
 AB251,Fairview,,Alberta,CA,56.0672,-118.384
-AB252,Falher,,Alberta,CA,55.7372,-117.20100000000001
+AB252,Falher,,Alberta,CA,55.7372,-117.201
 AB253,Fallis,,Alberta,CA,53.5853,-114.641
-AB254,Faust,,Alberta,CA,55.3158,-115.62799999999999
+AB254,Faust,,Alberta,CA,55.3158,-115.628
 AB255,Fawcett,,Alberta,CA,54.5394,-114.096
 AB256,Federal,,Alberta,CA,52.1117,-111.572
-AB257,Ferintosh,,Alberta,CA,52.7658,-112.97200000000001
+AB257,Ferintosh,,Alberta,CA,52.7658,-112.972
 AB258,Ferrier Acres,,Alberta,CA,52.3649,-115.061
-AB259,Fincastle,,Alberta,CA,49.8083,-112.00200000000001
-AB260,Fitzgerald,,Alberta,CA,59.8617,-111.60600000000001
+AB259,Fincastle,,Alberta,CA,49.8083,-112.002
+AB260,Fitzgerald,,Alberta,CA,59.8617,-111.606
 AB261,Flatbush,,Alberta,CA,54.6892,-114.156
 AB262,Fleet,,Alberta,CA,52.1533,-111.73
 AB263,Fleming Park,,Alberta,CA,53.4432,-113.72
@@ -267,31 +267,31 @@ AB265,Foremost,,Alberta,CA,49.4764,-111.447
 AB266,Forestburg,,Alberta,CA,52.5839,-112.064
 AB267,Forshee,,Alberta,CA,52.558,-114.145
 AB268,Fort Assiniboine,,Alberta,CA,54.3342,-114.775
-AB269,Fort Chipewyan,,Alberta,CA,58.7144,-111.15799999999999
+AB269,Fort Chipewyan,,Alberta,CA,58.7144,-111.158
 AB270,Fort Kent,,Alberta,CA,54.3108,-110.604
-AB271,Fort MacKay,,Alberta,CA,57.1869,-111.63600000000001
+AB271,Fort MacKay,,Alberta,CA,57.1869,-111.636
 AB272,Fort Macleod,,Alberta,CA,49.7231,-113.404
 AB273,Fort McMurray,,Alberta,CA,56.7275,-111.387
 AB274,Fort Saskatchewan,,Alberta,CA,53.7002,-113.225
 AB275,Fort Vermilion,,Alberta,CA,58.3893,-116.007
 AB276,Fox Creek,,Alberta,CA,54.4043,-116.81
-AB277,Fox Lake,,Alberta,CA,58.4705,-114.53299999999999
+AB277,Fox Lake,,Alberta,CA,58.4705,-114.533
 AB278,Frank,,Alberta,CA,49.6027,-114.406
 AB279,Frog Lake,,Alberta,CA,53.8721,-110.391
-AB280,Gadsby,,Alberta,CA,52.2968,-112.35600000000001
+AB280,Gadsby,,Alberta,CA,52.2968,-112.356
 AB281,Gainford,,Alberta,CA,53.5847,-114.785
 AB282,Galahad,,Alberta,CA,52.5142,-111.931
-AB283,Garden Creek,,Alberta,CA,58.7047,-113.88600000000001
+AB283,Garden Creek,,Alberta,CA,58.7047,-113.886
 AB284,Garden Grove Estates,,Alberta,CA,53.4836,-113.947
 AB285,Gem,,Alberta,CA,50.9506,-112.189
 AB286,Ghost Lake,,Alberta,CA,51.2066,-114.764
-AB287,Gibbons,,Alberta,CA,53.8297,-113.32799999999999
-AB288,Gift Lake,,Alberta,CA,55.8825,-115.81299999999999
+AB287,Gibbons,,Alberta,CA,53.8297,-113.328
+AB288,Gift Lake,,Alberta,CA,55.8825,-115.813
 AB289,Girouxville,,Alberta,CA,55.7536,-117.339
 AB290,Gleichen,,Alberta,CA,50.8661,-113.055
-AB291,Glen Leslie,,Alberta,CA,55.1994,-118.48700000000001
+AB291,Glen Leslie,,Alberta,CA,55.1994,-118.487
 AB292,Glendon,,Alberta,CA,54.2525,-111.16
-AB293,Glenevis,,Alberta,CA,53.7897,-114.51700000000001
+AB293,Glenevis,,Alberta,CA,53.7897,-114.517
 AB294,Glenwood,,Alberta,CA,49.3659,-113.515
 AB295,Glory Hills,,Alberta,CA,53.6828,-113.971
 AB296,Golden Days,,Alberta,CA,53.0514,-114.053
@@ -302,12 +302,12 @@ AB300,Grande Prairie,,Alberta,CA,55.1708,-118.796
 AB301,Grandview,,Alberta,CA,52.9879,-114.066
 AB302,Grantham,,Alberta,CA,50.0687,-112.009
 AB303,Granum,,Alberta,CA,49.8711,-113.508
-AB304,Grassland,,Alberta,CA,54.82,-112.68700000000001
+AB304,Grassland,,Alberta,CA,54.82,-112.687
 AB305,Grassy Lake,,Alberta,CA,49.8253,-111.698
 AB306,Green Acre Estates,,Alberta,CA,53.4979,-113.941
-AB307,Green Court,,Alberta,CA,54.0078,-115.23899999999999
+AB307,Green Court,,Alberta,CA,54.0078,-115.239
 AB308,Gregoire Lake Estates,,Alberta,CA,56.4669,-111.194
-AB309,Grimshaw,,Alberta,CA,56.1886,-117.60600000000001
+AB309,Grimshaw,,Alberta,CA,56.1886,-117.606
 AB310,Grouard,,Alberta,CA,55.5203,-116.161
 AB311,Grouard Mission,,Alberta,CA,55.5422,-116.154
 AB312,Grovedale,,Alberta,CA,55.0278,-118.859
@@ -316,7 +316,7 @@ AB314,Gunn,,Alberta,CA,53.7305,-114.348
 AB315,Guy,,Alberta,CA,55.5489,-117.12
 AB316,Gwynne,,Alberta,CA,52.9867,-113.199
 AB317,Hairy Hill,,Alberta,CA,53.7633,-111.979
-AB318,Half Moon Bay,,Alberta,CA,52.345,-114.17200000000001
+AB318,Half Moon Bay,,Alberta,CA,52.345,-114.172
 AB319,Half Moon Estates,,Alberta,CA,53.4615,-113.084
 AB320,Halkirk,,Alberta,CA,52.2825,-112.154
 AB321,Hanna,,Alberta,CA,51.6458,-111.925
@@ -326,71 +326,71 @@ AB324,Harvie Heights,,Alberta,CA,51.13,-115.376
 AB325,Hawk Hills,,Alberta,CA,57.2555,-117.413
 AB326,Hay Lakes,,Alberta,CA,53.1967,-113.057
 AB327,Hayfield,,Alberta,CA,55.1708,-119.615
-AB328,Haynes,,Alberta,CA,52.3175,-113.39200000000001
+AB328,Haynes,,Alberta,CA,52.3175,-113.392
 AB329,Hays,,Alberta,CA,50.0981,-111.794
-AB330,Hayter,,Alberta,CA,52.3564,-110.10799999999999
+AB330,Hayter,,Alberta,CA,52.3564,-110.108
 AB331,Hazell,,Alberta,CA,49.63,-114.664
 AB332,Heart Lake,,Alberta,CA,54.9832,-111.56
 AB333,Heinsburg,,Alberta,CA,53.7675,-110.522
-AB334,Heisler,,Alberta,CA,52.6711,-112.22399999999999
+AB334,Heisler,,Alberta,CA,52.6711,-112.224
 AB335,Heritage Woods,,Alberta,CA,51.0555,-114.241
 AB336,Herronton,,Alberta,CA,50.6247,-113.439
 AB337,Hesketh,,Alberta,CA,51.4703,-112.975
 AB338,Hewitt Estates,,Alberta,CA,53.8073,-113.397
-AB339,High Level,,Alberta,CA,58.516000000000005,-117.13799999999999
+AB339,High Level,,Alberta,CA,58.516,-117.138
 AB340,High Point Estates,,Alberta,CA,51.0309,-113.781
 AB341,High Prairie,,Alberta,CA,55.4347,-116.488
 AB342,High River,,Alberta,CA,50.5797,-113.874
-AB343,Hilda,,Alberta,CA,50.4797,-110.03299999999999
-AB344,Hill Spring,,Alberta,CA,49.2931,-113.62200000000001
-AB345,Hillcrest Mines,,Alberta,CA,49.5689,-114.37700000000001
-AB346,Hilliard,,Alberta,CA,53.64,-112.48200000000001
+AB343,Hilda,,Alberta,CA,50.4797,-110.033
+AB344,Hill Spring,,Alberta,CA,49.2931,-113.622
+AB345,Hillcrest Mines,,Alberta,CA,49.5689,-114.377
+AB346,Hilliard,,Alberta,CA,53.64,-112.482
 AB347,Hines Creek,,Alberta,CA,56.2486,-118.603
 AB348,Hinton,,Alberta,CA,53.4,-117.572
 AB349,Hobbema,,Alberta,CA,52.8194,-113.461
 AB350,Holden,,Alberta,CA,53.2333,-112.234
 AB351,Hondo,,Alberta,CA,55.0716,-114.039
 AB352,Horse Lake,,Alberta,CA,54.8229,-119.352
-AB353,Horseshoe Bay,,Alberta,CA,54.1262,-111.36399999999999
+AB353,Horseshoe Bay,,Alberta,CA,54.1262,-111.364
 AB354,Hu Haven,,Alberta,CA,53.7709,-113.205
 AB355,Hubbles Lake,,Alberta,CA,53.5593,-114.088
-AB356,Hughenden,,Alberta,CA,52.5106,-110.96700000000001
+AB356,Hughenden,,Alberta,CA,52.5106,-110.967
 AB357,Hussar,,Alberta,CA,51.0414,-112.682
 AB358,Huxley,,Alberta,CA,51.9243,-113.23
 AB359,Hylo,,Alberta,CA,54.6775,-112.211
 AB360,Hythe,,Alberta,CA,55.33,-119.55
 AB361,Iddesleigh,,Alberta,CA,50.7356,-111.303
-AB362,Imperial Mills,,Alberta,CA,55.0001,-111.73100000000001
+AB362,Imperial Mills,,Alberta,CA,55.0001,-111.731
 AB363,Indian Cabins,,Alberta,CA,59.8675,-117.035
 AB364,Indus,,Alberta,CA,50.9158,-113.78
-AB365,Innisfail,,Alberta,CA,52.0242,-113.95299999999999
+AB365,Innisfail,,Alberta,CA,52.0242,-113.953
 AB366,Innisfree,,Alberta,CA,53.3825,-111.531
 AB367,Irma,,Alberta,CA,52.9119,-111.228
-AB368,Iron Springs,,Alberta,CA,49.93,-112.68799999999999
-AB369,Irricana,,Alberta,CA,51.3236,-113.60799999999999
+AB368,Iron Springs,,Alberta,CA,49.93,-112.688
+AB369,Irricana,,Alberta,CA,51.3236,-113.608
 AB370,Irvine,,Alberta,CA,49.9553,-110.277
-AB371,Island Lake,,Alberta,CA,54.8415,-113.55799999999999
+AB371,Island Lake,,Alberta,CA,54.8415,-113.558
 AB372,Islay,,Alberta,CA,53.3939,-110.539
 AB373,Itaska Beach,,Alberta,CA,53.0722,-114.08
 AB374,Jarrow,,Alberta,CA,52.9408,-111.395
-AB375,Jarvie,,Alberta,CA,54.4547,-113.98700000000001
+AB375,Jarvie,,Alberta,CA,54.4547,-113.987
 AB376,Jarvis Bay,,Alberta,CA,52.3352,-114.08
-AB377,Jasper,,Alberta,CA,52.8711,-118.09299999999999
+AB377,Jasper,,Alberta,CA,52.8711,-118.093
 AB378,Jean Côté,,Alberta,CA,55.8981,-117.311
 AB379,Jenner,,Alberta,CA,50.7467,-111.184
 AB380,Joffre,,Alberta,CA,52.3371,-113.537
-AB381,John D'Or Prairie,,Alberta,CA,58.4938,-115.14399999999999
+AB381,John D'Or Prairie,,Alberta,CA,58.4938,-115.144
 AB382,Johnson's Addition,,Alberta,CA,49.7827,-112.177
 AB383,Josephburg,,Alberta,CA,53.7133,-113.07
-AB384,Joussard,,Alberta,CA,55.3952,-115.95100000000001
+AB384,Joussard,,Alberta,CA,55.3952,-115.951
 AB385,Judson,,Alberta,CA,49.5222,-112.346
 AB386,Kapasiwin,,Alberta,CA,53.5442,-114.445
 AB387,Kapawe'no,,Alberta,CA,55.5475,-116.152
 AB388,Kathyrn,,Alberta,CA,51.2183,-113.708
-AB389,Kavanagh,,Alberta,CA,53.1822,-113.51700000000001
+AB389,Kavanagh,,Alberta,CA,53.1822,-113.517
 AB390,Keg River,,Alberta,CA,57.746,-117.61
 AB391,Kehewin,,Alberta,CA,54.1104,-110.882
-AB392,Kelsey,,Alberta,CA,52.8458,-112.54899999999999
+AB392,Kelsey,,Alberta,CA,52.8458,-112.549
 AB393,Keoma,,Alberta,CA,51.2169,-113.649
 AB394,Kew,,Alberta,CA,50.7329,-114.417
 AB395,Kikino,,Alberta,CA,54.4442,-112.094
@@ -402,19 +402,19 @@ AB400,Kirkcaldy,,Alberta,CA,50.335,-113.238
 AB401,Kitscoty,,Alberta,CA,53.3419,-110.333
 AB402,La Crete,,Alberta,CA,58.1878,-116.417
 AB403,La Glace,,Alberta,CA,55.4028,-119.154
-AB404,Lac des Arcs,,Alberta,CA,51.0501,-115.15700000000001
+AB404,Lac des Arcs,,Alberta,CA,51.0501,-115.157
 AB405,Lac La Biche,,Alberta,CA,54.7686,-111.978
 AB406,Lacombe,,Alberta,CA,52.4644,-113.734
 AB407,Lake Louise,,Alberta,CA,51.4253,-116.181
-AB408,Lakeview,,Alberta,CA,53.5597,-114.45700000000001
-AB409,Lamont,,Alberta,CA,53.7625,-112.77799999999999
+AB408,Lakeview,,Alberta,CA,53.5597,-114.457
+AB409,Lamont,,Alberta,CA,53.7625,-112.778
 AB410,Lancaster Park,,Alberta,CA,53.6728,-113.491
 AB411,Langdon,,Alberta,CA,50.9737,-113.67
-AB412,Larkspur,,Alberta,CA,54.4387,-113.76799999999999
+AB412,Larkspur,,Alberta,CA,54.4387,-113.768
 AB413,Lavoy,,Alberta,CA,53.4587,-111.863
-AB414,Lawsonburg,,Alberta,CA,51.4836,-112.15899999999999
-AB415,Leahurst,,Alberta,CA,52.3763,-112.64399999999999
-AB416,Leavitt,,Alberta,CA,49.1709,-113.45299999999999
+AB414,Lawsonburg,,Alberta,CA,51.4836,-112.159
+AB415,Leahurst,,Alberta,CA,52.3763,-112.644
+AB416,Leavitt,,Alberta,CA,49.1709,-113.453
 AB417,Leduc,,Alberta,CA,53.2667,-113.546
 AB418,Leedale,,Alberta,CA,52.5819,-114.47
 AB419,Legal,,Alberta,CA,53.9495,-113.595
@@ -422,18 +422,18 @@ AB420,Legend,,Alberta,CA,49.4844,-111.61
 AB421,Les Trailer Park,,Alberta,CA,52.2786,-113.867
 AB422,Leslieville,,Alberta,CA,52.3833,-114.605
 AB423,Lethbridge,,Alberta,CA,49.6928,-112.835
-AB424,Lindbergh,,Alberta,CA,53.8875,-110.67299999999999
+AB424,Lindbergh,,Alberta,CA,53.8875,-110.673
 AB425,Linden,,Alberta,CA,51.5906,-113.488
-AB426,Linn Valley,,Alberta,CA,52.3214,-113.87299999999999
-AB427,Little Buffalo,,Alberta,CA,56.4375,-116.10799999999999
-AB428,Lloydminster,,Alberta,CA,53.278999999999996,-110.01899999999999
+AB426,Linn Valley,,Alberta,CA,52.3214,-113.873
+AB427,Little Buffalo,,Alberta,CA,56.4375,-116.108
+AB428,Lloydminster,,Alberta,CA,53.279,-110.019
 AB429,Lodgepole,,Alberta,CA,53.1006,-115.314
 AB430,Lomond,,Alberta,CA,50.3494,-112.641
 AB431,Lone Pine,,Alberta,CA,54.3058,-115.115
 AB432,Long Lake,,Alberta,CA,54.4517,-112.775
-AB433,Longview,,Alberta,CA,50.5308,-114.23100000000001
-AB434,Loon Lake,,Alberta,CA,56.5389,-115.39399999999999
-AB435,Lougheed,,Alberta,CA,52.7444,-111.54299999999999
+AB433,Longview,,Alberta,CA,50.5308,-114.231
+AB434,Loon Lake,,Alberta,CA,56.5389,-115.394
+AB435,Lougheed,,Alberta,CA,52.7444,-111.543
 AB436,Louis Bull,,Alberta,CA,52.8887,-113.541
 AB437,Lousana,,Alberta,CA,52.1128,-113.19
 AB438,Loyalist,,Alberta,CA,51.9858,-110.954
@@ -443,14 +443,14 @@ AB441,Ma-Me-O Beach,,Alberta,CA,52.9735,-113.96
 AB442,Magrath,,Alberta,CA,49.417,-112.865
 AB443,Makepeace,,Alberta,CA,50.9394,-112.616
 AB444,Mallaig,,Alberta,CA,54.2103,-111.361
-AB445,Manning,,Alberta,CA,56.92,-117.62899999999999
+AB445,Manning,,Alberta,CA,56.92,-117.629
 AB446,Mannville,,Alberta,CA,53.3403,-111.178
 AB447,Manyberries,,Alberta,CA,49.4006,-110.695
 AB448,Markerville,,Alberta,CA,52.1236,-114.171
 AB449,Marlboro,,Alberta,CA,53.5556,-116.796
-AB450,Martins Trailer Court,,Alberta,CA,52.3597,-115.02799999999999
+AB450,Martins Trailer Court,,Alberta,CA,52.3597,-115.028
 AB451,Marwayne,,Alberta,CA,53.5175,-110.33
-AB452,Mayerthorpe,,Alberta,CA,53.9547,-115.13799999999999
+AB452,Mayerthorpe,,Alberta,CA,53.9547,-115.138
 AB453,McDermott,,Alberta,CA,49.7309,-112.948
 AB454,McLaughlin,,Alberta,CA,52.9897,-110.165
 AB455,McLennan,,Alberta,CA,55.7062,-116.906
@@ -459,47 +459,47 @@ AB457,McNab,,Alberta,CA,49.3494,-112.29
 AB458,Meander River,,Alberta,CA,59.0434,-117.714
 AB459,Meanook,,Alberta,CA,54.5766,-113.319
 AB460,Medicine Hat,,Alberta,CA,50.0408,-110.677
-AB461,Medley,,Alberta,CA,54.4191,-110.26799999999999
-AB462,Meeting Creek,,Alberta,CA,52.6819,-112.73200000000001
-AB463,Meso West,,Alberta,CA,53.5915,-114.30799999999999
+AB461,Medley,,Alberta,CA,54.4191,-110.268
+AB462,Meeting Creek,,Alberta,CA,52.6819,-112.732
+AB463,Meso West,,Alberta,CA,53.5915,-114.308
 AB464,Metiskow,,Alberta,CA,52.4086,-110.633
 AB465,Mewatha Beach,,Alberta,CA,54.6065,-112.741
-AB466,Michichi,,Alberta,CA,51.5853,-112.53399999999999
+AB466,Michichi,,Alberta,CA,51.5853,-112.534
 AB467,Mikisew,,Alberta,CA,58.7678,-111.046
 AB468,Milk River,,Alberta,CA,49.1554,-112.083
 AB469,Millarville,,Alberta,CA,50.7564,-114.325
 AB470,Millet,,Alberta,CA,53.0923,-113.473
 AB471,Millicent,,Alberta,CA,50.7103,-111.779
 AB472,Milo,,Alberta,CA,50.57,-112.882
-AB473,Minburn,,Alberta,CA,53.3156,-111.36399999999999
+AB473,Minburn,,Alberta,CA,53.3156,-111.364
 AB474,Mirror,,Alberta,CA,52.4656,-113.11
-AB475,Monarch,,Alberta,CA,49.8044,-113.10799999999999
+AB475,Monarch,,Alberta,CA,49.8044,-113.108
 AB476,Monitor,,Alberta,CA,51.9783,-110.569
-AB477,Montana,,Alberta,CA,52.7271,-113.42399999999999
+AB477,Montana,,Alberta,CA,52.7271,-113.424
 AB478,Moon River Estates,,Alberta,CA,49.7286,-113.149
 AB479,Moose Portage,,Alberta,CA,55.2292,-113.883
-AB480,Morinville,,Alberta,CA,53.8028,-113.64399999999999
+AB480,Morinville,,Alberta,CA,53.8028,-113.644
 AB481,Morley,,Alberta,CA,51.1672,-114.852
 AB482,Morningside,,Alberta,CA,52.5778,-113.634
-AB483,Morrin,,Alberta,CA,51.6603,-112.76700000000001
+AB483,Morrin,,Alberta,CA,51.6603,-112.767
 AB484,Mossleigh,,Alberta,CA,50.7203,-113.324
 AB485,Mountain View,,Alberta,CA,49.1344,-113.596
-AB486,Mulhurst,,Alberta,CA,53.0493,-113.98100000000001
-AB487,Mundare,,Alberta,CA,53.5939,-112.34200000000001
+AB486,Mulhurst,,Alberta,CA,53.0493,-113.981
+AB487,Mundare,,Alberta,CA,53.5939,-112.342
 AB488,Munson,,Alberta,CA,51.5633,-112.738
 AB489,Musidora,,Alberta,CA,53.6897,-111.584
 AB490,Myrnam,,Alberta,CA,53.6617,-111.23
-AB491,Nacmine,,Alberta,CA,51.47,-112.78399999999999
+AB491,Nacmine,,Alberta,CA,51.47,-112.784
 AB492,Nakamun Park,,Alberta,CA,53.8776,-114.214
 AB493,Namaka,,Alberta,CA,50.9583,-113.287
-AB494,Namao,,Alberta,CA,53.7671,-113.47399999999999
+AB494,Namao,,Alberta,CA,53.7671,-113.474
 AB495,Nampa,,Alberta,CA,56.0381,-117.13
-AB496,Nanton,,Alberta,CA,50.346000000000004,-113.777
-AB497,Neerlandia,,Alberta,CA,54.3192,-114.37700000000001
+AB496,Nanton,,Alberta,CA,50.346,-113.777
+AB497,Neerlandia,,Alberta,CA,54.3192,-114.377
 AB498,Nevis,,Alberta,CA,52.3303,-113.031
 AB499,New Brigden,,Alberta,CA,51.7006,-110.49
 AB500,New Dayton,,Alberta,CA,49.4256,-112.381
-AB501,New Norway,,Alberta,CA,52.8689,-112.95100000000001
+AB501,New Norway,,Alberta,CA,52.8689,-112.951
 AB502,New Sarepta,,Alberta,CA,53.2742,-113.146
 AB503,Newbrook,,Alberta,CA,54.326,-112.949
 AB504,Nightingale,,Alberta,CA,51.1603,-113.333
@@ -513,208 +513,208 @@ AB511,O'Chiese,,Alberta,CA,52.6839,-115.256
 AB512,Obed,,Alberta,CA,53.5583,-117.215
 AB513,Ohaton,,Alberta,CA,52.97,-112.661
 AB514,Okotoks,,Alberta,CA,50.7261,-113.977
-AB515,Olds,,Alberta,CA,51.7919,-114.10700000000001
-AB516,Onoway,,Alberta,CA,53.7025,-114.19200000000001
+AB515,Olds,,Alberta,CA,51.7919,-114.107
+AB516,Onoway,,Alberta,CA,53.7025,-114.192
 AB517,Orton,,Alberta,CA,49.732,-113.264
 AB518,Osborne Acres,,Alberta,CA,53.558,-113.8
-AB519,Oyen,,Alberta,CA,51.3528,-110.48299999999999
-AB520,Paddle Prairie,,Alberta,CA,57.9511,-117.47200000000001
-AB521,Panorama Heights,,Alberta,CA,53.6318,-113.94200000000001
+AB519,Oyen,,Alberta,CA,51.3528,-110.483
+AB520,Paddle Prairie,,Alberta,CA,57.9511,-117.472
+AB521,Panorama Heights,,Alberta,CA,53.6318,-113.942
 AB522,Paradise Valley,,Alberta,CA,53.0328,-110.296
-AB523,Parkland,,Alberta,CA,50.2561,-113.65899999999999
+AB523,Parkland,,Alberta,CA,50.2561,-113.659
 AB524,Parkland Beach,,Alberta,CA,52.6072,-114.065
 AB525,Patricia,,Alberta,CA,50.6994,-111.677
 AB526,Peace River,,Alberta,CA,56.2389,-117.292
-AB527,Peavine Metis Settlement,,Alberta,CA,55.7845,-116.29700000000001
+AB527,Peavine Metis Settlement,,Alberta,CA,55.7845,-116.297
 AB528,Peerless Lake,,Alberta,CA,56.6804,-114.581
 AB529,Peers,,Alberta,CA,53.6658,-115.993
 AB530,Pelican Narrows,,Alberta,CA,54.2629,-110.89
 AB531,Pemukan,,Alberta,CA,51.9719,-110.444
-AB532,Penhold,,Alberta,CA,52.1369,-113.87299999999999
+AB532,Penhold,,Alberta,CA,52.1369,-113.873
 AB533,Perryvale,,Alberta,CA,54.4678,-113.387
-AB534,Peterburn Estates,,Alberta,CA,53.4952,-113.96600000000001
+AB534,Peterburn Estates,,Alberta,CA,53.4952,-113.966
 AB535,Pibroch,,Alberta,CA,54.2544,-113.875
 AB536,Pickardville,,Alberta,CA,54.0519,-113.881
 AB537,Picture Butte,,Alberta,CA,49.8769,-112.78
 AB538,Pincher,,Alberta,CA,49.5248,-113.947
 AB539,Pincher Creek,,Alberta,CA,49.4853,-113.947
-AB540,Pine Lake,,Alberta,CA,52.1103,-113.48200000000001
+AB540,Pine Lake,,Alberta,CA,52.1103,-113.482
 AB541,Pine Shadows,,Alberta,CA,53.6031,-116.305
 AB542,Pipestone,,Alberta,CA,53.0536,-113.795
-AB543,Plamondon,,Alberta,CA,54.8497,-112.34200000000001
+AB543,Plamondon,,Alberta,CA,54.8497,-112.342
 AB544,Point Alison,,Alberta,CA,53.5503,-114.486
 AB545,Pollockville,,Alberta,CA,51.1061,-111.59
 AB546,Ponoka,,Alberta,CA,52.675,-113.58
-AB547,Poplar Bay,,Alberta,CA,53.0078,-114.12100000000001
-AB548,Poplar Ridge,,Alberta,CA,52.2994,-113.93700000000001
+AB547,Poplar Bay,,Alberta,CA,53.0078,-114.121
+AB548,Poplar Ridge,,Alberta,CA,52.2994,-113.937
 AB549,Prairie Lodge Trailer Court,,Alberta,CA,53.5145,-112.052
 AB550,Priddis,,Alberta,CA,50.8861,-114.329
 AB551,Provost,,Alberta,CA,52.3533,-110.265
-AB552,Purple Springs,,Alberta,CA,49.8156,-111.89200000000001
+AB552,Purple Springs,,Alberta,CA,49.8156,-111.892
 AB553,Queenstown,,Alberta,CA,50.6394,-112.939
 AB554,Radway,,Alberta,CA,54.06,-112.945
 AB555,Rainbow Lake,,Alberta,CA,58.5044,-119.4
-AB556,Rainier,,Alberta,CA,50.3683,-112.09200000000001
+AB556,Rainier,,Alberta,CA,50.3683,-112.092
 AB557,Ralston,,Alberta,CA,50.2458,-111.169
 AB558,Ranfurly,,Alberta,CA,53.4072,-111.68
 AB559,Raymond,,Alberta,CA,49.465,-112.661
 AB560,Red Deer,,Alberta,CA,52.2686,-113.81
-AB561,Red Earth Creek,,Alberta,CA,56.5363,-115.29799999999999
+AB561,Red Earth Creek,,Alberta,CA,56.5363,-115.298
 AB562,Red Willow,,Alberta,CA,52.4504,-112.573
 AB563,Redcliff,,Alberta,CA,50.0775,-110.786
 AB564,Redland,,Alberta,CA,51.2897,-113.008
-AB565,Redwater,,Alberta,CA,53.9508,-113.10700000000001
+AB565,Redwater,,Alberta,CA,53.9508,-113.107
 AB566,Reno,,Alberta,CA,55.9943,-117.0
 AB567,Rich Lake,,Alberta,CA,54.5078,-111.619
 AB568,Rich Valley,,Alberta,CA,53.8483,-114.35
 AB569,Richdale,,Alberta,CA,51.6103,-111.604
-AB570,Rimbey,,Alberta,CA,52.6392,-114.23700000000001
-AB571,Riverview,,Alberta,CA,53.8619,-110.64200000000001
+AB570,Rimbey,,Alberta,CA,52.6392,-114.237
+AB571,Riverview,,Alberta,CA,53.8619,-110.642
 AB572,Riverview Pines,,Alberta,CA,55.0875,-118.946
 AB573,Robb,,Alberta,CA,53.2333,-116.979
 AB574,Rochester,,Alberta,CA,54.3725,-113.461
 AB575,Rochfort Bridge,,Alberta,CA,53.9136,-115.036
-AB576,Rochon Sands,,Alberta,CA,52.45399999999999,-112.882
+AB576,Rochon Sands,,Alberta,CA,52.454,-112.882
 AB577,Rocky Lane,,Alberta,CA,58.4588,-116.259
 AB578,Rocky Mountain House,,Alberta,CA,52.3793,-114.919
-AB579,Rocky Rapids,,Alberta,CA,53.2797,-114.95200000000001
-AB580,Rockyford,,Alberta,CA,51.2342,-113.14200000000001
+AB579,Rocky Rapids,,Alberta,CA,53.2797,-114.952
+AB580,Rockyford,,Alberta,CA,51.2342,-113.142
 AB581,Rolling Heights,,Alberta,CA,53.6383,-113.992
 AB582,Rolling Hills,,Alberta,CA,50.2256,-111.774
 AB583,Rolling Meadows,,Alberta,CA,53.5826,-113.854
-AB584,Rolly View,,Alberta,CA,53.2528,-113.31700000000001
+AB584,Rolly View,,Alberta,CA,53.2528,-113.317
 AB585,Rosalind,,Alberta,CA,52.7897,-112.444
 AB586,Rose Lynn,,Alberta,CA,51.4178,-111.677
-AB587,Rosebud,,Alberta,CA,51.2997,-112.95100000000001
+AB587,Rosebud,,Alberta,CA,51.2997,-112.951
 AB588,Rosedale,,Alberta,CA,51.4167,-112.633
 AB589,Rosemary,,Alberta,CA,50.7575,-112.09
-AB590,Ross Haven,,Alberta,CA,53.7342,-114.40799999999999
-AB591,Rossian,,Alberta,CA,54.9545,-112.37100000000001
+AB590,Ross Haven,,Alberta,CA,53.7342,-114.408
+AB591,Rossian,,Alberta,CA,54.9545,-112.371
 AB592,Round Hill,,Alberta,CA,53.1653,-112.631
 AB593,Rowley,,Alberta,CA,51.7622,-112.788
-AB594,Rumsey,,Alberta,CA,51.8419,-112.84200000000001
+AB594,Rumsey,,Alberta,CA,51.8419,-112.842
 AB595,Rycroft,,Alberta,CA,55.7558,-118.709
 AB596,Ryley,,Alberta,CA,53.2908,-112.43
-AB597,Saddle Lake,,Alberta,CA,53.9559,-111.70100000000001
+AB597,Saddle Lake,,Alberta,CA,53.9559,-111.701
 AB598,Samson Peak,,Alberta,CA,52.6806,-117.5273
 AB599,Sandy Beach,,Alberta,CA,53.8084,-114.039
 AB600,Sandy Lake,,Alberta,CA,55.8144,-113.416
 AB601,Sangudo,,Alberta,CA,53.8879,-114.895
-AB602,Saprae Creek,,Alberta,CA,56.6592,-111.14299999999999
+AB602,Saprae Creek,,Alberta,CA,56.6592,-111.143
 AB603,Saskatchewan River Crossing,,Alberta,CA,51.9758,-116.743
 AB604,Sawridge,,Alberta,CA,55.3117,-114.868
 AB605,Sawridge,,Alberta,CA,55.2901,-114.75
-AB606,Scandia,,Alberta,CA,50.2781,-112.04700000000001
+AB606,Scandia,,Alberta,CA,50.2781,-112.047
 AB607,Schuler,,Alberta,CA,50.3407,-110.089
 AB608,Scollard,,Alberta,CA,51.9375,-112.834
 AB609,Seba Beach,,Alberta,CA,53.5593,-114.734
 AB610,Sedalia,,Alberta,CA,51.675,-110.665
 AB611,Sedgewick,,Alberta,CA,52.7747,-111.693
-AB612,Seven Persons,,Alberta,CA,49.8761,-110.90799999999999
-AB613,Sexsmith,,Alberta,CA,55.3503,-118.78200000000001
-AB614,Shaughnessy,,Alberta,CA,49.8528,-112.84200000000001
-AB615,Shepard,,Alberta,CA,50.953,-113.90799999999999
+AB612,Seven Persons,,Alberta,CA,49.8761,-110.908
+AB613,Sexsmith,,Alberta,CA,55.3503,-118.782
+AB614,Shaughnessy,,Alberta,CA,49.8528,-112.842
+AB615,Shepard,,Alberta,CA,50.953,-113.908
 AB616,Sherwood Park,,Alberta,CA,53.5339,-113.29
-AB617,Shouldice,,Alberta,CA,50.7167,-112.97399999999999
+AB617,Shouldice,,Alberta,CA,50.7167,-112.974
 AB618,Sibbald,,Alberta,CA,51.3883,-110.15
 AB619,Siksika,,Alberta,CA,50.7924,-112.855
 AB620,Silver Beach,,Alberta,CA,53.0368,-113.994
-AB621,Silver Sands,,Alberta,CA,53.6369,-114.65700000000001
+AB621,Silver Sands,,Alberta,CA,53.6369,-114.657
 AB622,Skiff,,Alberta,CA,49.5025,-111.791
 AB623,Slave Lake,,Alberta,CA,55.2822,-114.77
 AB624,Smith,,Alberta,CA,55.162,-114.041
-AB625,Smoky Lake,,Alberta,CA,54.1167,-112.46700000000001
+AB625,Smoky Lake,,Alberta,CA,54.1167,-112.467
 AB626,South Baptiste,,Alberta,CA,54.7219,-113.573
 AB627,South View,,Alberta,CA,53.6468,-114.663
 AB628,Spedden,,Alberta,CA,54.1386,-111.726
 AB629,Spirit River,,Alberta,CA,55.7786,-118.837
 AB630,Spring Coulee,,Alberta,CA,49.3331,-113.053
 AB631,Spring Lake,,Alberta,CA,53.5186,-114.133
-AB632,Springbrook,,Alberta,CA,52.1767,-113.87200000000001
+AB632,Springbrook,,Alberta,CA,52.1767,-113.872
 AB633,Spruce Grove,,Alberta,CA,53.5539,-113.902
-AB634,Spruce Lane Acres,,Alberta,CA,52.3503,-113.81299999999999
+AB634,Spruce Lane Acres,,Alberta,CA,52.3503,-113.813
 AB635,Spruce View,,Alberta,CA,52.0856,-114.31
-AB636,Sputinow,,Alberta,CA,53.9219,-110.26799999999999
+AB636,Sputinow,,Alberta,CA,53.9219,-110.268
 AB637,St. Albert,,Alberta,CA,53.6369,-113.62
-AB638,St. Isidore,,Alberta,CA,56.20399999999999,-117.10700000000001
+AB638,St. Isidore,,Alberta,CA,56.204,-117.107
 AB639,St. Lina,,Alberta,CA,54.2961,-111.454
-AB640,St. Michael,,Alberta,CA,53.8303,-112.63600000000001
+AB640,St. Michael,,Alberta,CA,53.8303,-112.636
 AB641,St. Paul,St-Paul-de-Métis,Alberta,CA,53.9913,-111.3269
 AB642,St. Paul,,Alberta,CA,53.9928,-111.296
 AB643,Stand Off,,Alberta,CA,49.4569,-113.303
 AB644,Standard,,Alberta,CA,51.1097,-112.984
-AB645,Stavely,,Alberta,CA,50.1611,-113.64200000000001
+AB645,Stavely,,Alberta,CA,50.1611,-113.642
 AB646,Steen River,,Alberta,CA,59.6275,-117.167
 AB647,Stettler,,Alberta,CA,52.3239,-112.704
 AB648,Stirling,,Alberta,CA,49.5032,-112.527
-AB649,Stonelaw,,Alberta,CA,51.8686,-112.48100000000001
+AB649,Stonelaw,,Alberta,CA,51.8686,-112.481
 AB650,Stony Plain,,Alberta,CA,53.5264,-114.007
-AB651,Strathmore,,Alberta,CA,51.0456,-113.39299999999999
-AB652,Strome,,Alberta,CA,52.8108,-112.06700000000001
+AB651,Strathmore,,Alberta,CA,51.0456,-113.393
+AB652,Strome,,Alberta,CA,52.8108,-112.067
 AB653,Sturgeon Lake,,Alberta,CA,55.1286,-117.476
-AB654,Sturgeon Lake,,Alberta,CA,55.0695,-117.48899999999999
+AB654,Sturgeon Lake,,Alberta,CA,55.0695,-117.489
 AB655,Suffield,,Alberta,CA,50.2183,-111.161
-AB656,Sunbreaker Cove,,Alberta,CA,52.3875,-114.18700000000001
+AB656,Sunbreaker Cove,,Alberta,CA,52.3875,-114.187
 AB657,Sunchild,,Alberta,CA,52.6935,-115.33
-AB658,Sundance Beach,,Alberta,CA,53.0809,-114.12100000000001
+AB658,Sundance Beach,,Alberta,CA,53.0809,-114.121
 AB659,Sundre,,Alberta,CA,51.7983,-114.64
-AB660,Sunnybrook,,Alberta,CA,53.193000000000005,-114.2
-AB661,Sunnyslope,,Alberta,CA,51.648999999999994,-113.55799999999999
+AB660,Sunnybrook,,Alberta,CA,53.193,-114.2
+AB661,Sunnyslope,,Alberta,CA,51.649,-113.558
 AB662,Sunrise Beach,,Alberta,CA,53.7838,-114.055
 AB663,Sunset Beach,,Alberta,CA,54.7415,-113.541
-AB664,Sunset House,,Alberta,CA,55.111999999999995,-116.899
+AB664,Sunset House,,Alberta,CA,55.112,-116.899
 AB665,Sunset Point,,Alberta,CA,53.6888,-114.353
 AB666,Sunset View Acres,,Alberta,CA,53.4502,-113.744
 AB667,Swalwell,,Alberta,CA,51.5572,-113.318
-AB668,Swan City Trailer Court,,Alberta,CA,55.1694,-118.75399999999999
+AB668,Swan City Trailer Court,,Alberta,CA,55.1694,-118.754
 AB669,Swan Hills,,Alberta,CA,54.7167,-115.402
-AB670,Swan River,,Alberta,CA,55.3402,-115.45100000000001
+AB670,Swan River,,Alberta,CA,55.3402,-115.451
 AB671,Sylvan Lake,,Alberta,CA,52.3047,-114.1145
 AB672,Sylvan Lake,,Alberta,CA,52.3057,-114.096
 AB673,T & E Trailer Park,,Alberta,CA,55.1766,-118.751
-AB674,Taber,,Alberta,CA,49.7848,-112.15100000000001
-AB675,Tallcree,,Alberta,CA,57.9119,-115.35600000000001
+AB674,Taber,,Alberta,CA,49.7848,-112.151
+AB675,Tallcree,,Alberta,CA,57.9119,-115.356
 AB676,Tawatinaw,,Alberta,CA,54.2979,-113.477
 AB677,Tees,,Alberta,CA,52.4675,-113.321
 AB678,Therien,,Alberta,CA,54.2389,-111.255
 AB679,Thorhild,,Alberta,CA,54.1589,-113.125
-AB680,Thorsby,,Alberta,CA,53.2269,-114.04799999999999
-AB681,Three Hills,,Alberta,CA,51.7031,-113.26899999999999
+AB680,Thorsby,,Alberta,CA,53.2269,-114.048
+AB681,Three Hills,,Alberta,CA,51.7031,-113.269
 AB682,Throne,,Alberta,CA,52.0534,-111.288
-AB683,Tilley,,Alberta,CA,50.4522,-111.65299999999999
+AB683,Tilley,,Alberta,CA,50.4522,-111.653
 AB684,Tofield,,Alberta,CA,53.3708,-112.666
-AB685,Tomahawk,,Alberta,CA,53.3979,-114.76299999999999
-AB686,Torrington,,Alberta,CA,51.7914,-113.60600000000001
+AB685,Tomahawk,,Alberta,CA,53.3979,-114.763
+AB686,Torrington,,Alberta,CA,51.7914,-113.606
 AB687,Travers,,Alberta,CA,50.2481,-112.555
 AB688,Triple-L-Trailer Court,,Alberta,CA,55.1687,-118.65
 AB689,Trochu,,Alberta,CA,51.8286,-113.228
-AB690,Trout Lake,,Alberta,CA,56.4958,-114.55799999999999
+AB690,Trout Lake,,Alberta,CA,56.4958,-114.558
 AB691,Tsuu T'ina,,Alberta,CA,50.9515,-114.166
 AB692,Tulliby Lake,,Alberta,CA,53.7139,-110.177
-AB693,Turin,,Alberta,CA,49.9641,-112.52799999999999
+AB693,Turin,,Alberta,CA,49.9641,-112.528
 AB694,Turner Valley,,Alberta,CA,50.6753,-114.28
-AB695,Tuttle,,Alberta,CA,52.2012,-113.84299999999999
-AB696,Twining,,Alberta,CA,51.6328,-113.29700000000001
+AB695,Tuttle,,Alberta,CA,52.2012,-113.843
+AB696,Twining,,Alberta,CA,51.6328,-113.297
 AB697,Two Hills,,Alberta,CA,53.7111,-111.745
 AB698,Upper and Lower Viscount Estates,,Alberta,CA,53.6748,-113.561
 AB699,Upper Manor Estates,,Alberta,CA,53.6874,-113.575
-AB700,Val Quentin,,Alberta,CA,53.663999999999994,-114.385
+AB700,Val Quentin,,Alberta,CA,53.664,-114.385
 AB701,Valhalla Centre,,Alberta,CA,55.4036,-119.382
-AB702,Valleyview,,Alberta,CA,55.0659,-117.28200000000001
-AB703,Vauxhall,,Alberta,CA,50.0683,-112.10700000000001
+AB702,Valleyview,,Alberta,CA,55.0659,-117.282
+AB703,Vauxhall,,Alberta,CA,50.0683,-112.107
 AB704,Vegreville,,Alberta,CA,53.4977,-112.1015
 AB705,Vegreville,,Alberta,CA,53.4956,-112.052
 AB706,Venice,,Alberta,CA,54.6978,-112.148
 AB707,Vermilion,,Alberta,CA,53.3547,-110.853
 AB708,Veteran,,Alberta,CA,52.0011,-111.119
-AB709,Viking,,Alberta,CA,53.0947,-111.77600000000001
+AB709,Viking,,Alberta,CA,53.0947,-111.776
 AB710,Villeneuve,,Alberta,CA,53.66,-113.811
 AB711,Vilna,,Alberta,CA,54.1167,-111.921
 AB712,Vimy,,Alberta,CA,54.0621,-113.647
 AB713,Violet Grove,,Alberta,CA,53.1597,-115.037
-AB714,Vulcan,,Alberta,CA,50.4042,-113.26100000000001
-AB715,Wabamun,,Alberta,CA,53.5609,-114.47200000000001
-AB716,Wabasca-Desmarais,,Alberta,CA,55.9792,-113.84299999999999
+AB714,Vulcan,,Alberta,CA,50.4042,-113.261
+AB715,Wabamun,,Alberta,CA,53.5609,-114.472
+AB716,Wabasca-Desmarais,,Alberta,CA,55.9792,-113.843
 AB717,Wainwright,,Alberta,CA,52.8382,-110.853
 AB718,Waiparous,,Alberta,CA,51.2828,-114.835
 AB719,Walsh,,Alberta,CA,49.9472,-110.042
@@ -724,42 +724,42 @@ AB722,Warburg,,Alberta,CA,53.1817,-114.32
 AB723,Warden,,Alberta,CA,52.2592,-112.742
 AB724,Wardlow,,Alberta,CA,50.9053,-111.546
 AB725,Warner,,Alberta,CA,49.2828,-112.208
-AB726,Warspite,,Alberta,CA,54.0911,-112.61399999999999
+AB726,Warspite,,Alberta,CA,54.0911,-112.614
 AB727,Warwick,,Alberta,CA,53.6272,-112.052
-AB728,Waskatenau,,Alberta,CA,54.0939,-112.78399999999999
+AB728,Waskatenau,,Alberta,CA,54.0939,-112.784
 AB729,Water Valley,,Alberta,CA,51.5061,-114.611
 AB730,Waterton Park,,Alberta,CA,49.0517,-113.914
 AB731,Watino,,Alberta,CA,55.7126,-117.624
-AB732,Wayne,,Alberta,CA,51.3815,-112.65799999999999
-AB733,Webster,,Alberta,CA,55.4419,-118.68799999999999
+AB732,Wayne,,Alberta,CA,51.3815,-112.658
+AB733,Webster,,Alberta,CA,55.4419,-118.688
 AB734,Welling,,Alberta,CA,49.4811,-112.786
 AB735,Wembley,,Alberta,CA,55.1556,-119.146
 AB736,West Baptiste,,Alberta,CA,54.7622,-113.574
-AB737,West Cove,,Alberta,CA,53.6983,-114.50399999999999
+AB737,West Cove,,Alberta,CA,53.6983,-114.504
 AB738,Westbrooke Crescents,,Alberta,CA,53.5926,-113.971
 AB739,Westlake Estates,,Alberta,CA,53.5283,-114.079
-AB740,Westlock,,Alberta,CA,54.1553,-113.85700000000001
-AB741,Wetaskiwin,,Alberta,CA,52.9692,-113.37700000000001
+AB740,Westlock,,Alberta,CA,54.1553,-113.857
+AB741,Wetaskiwin,,Alberta,CA,52.9692,-113.377
 AB742,Whispering Hills,,Alberta,CA,54.7584,-113.552
-AB743,Whitburn,,Alberta,CA,55.8689,-119.20200000000001
-AB744,White Sands,,Alberta,CA,52.4667,-112.81700000000001
+AB743,Whitburn,,Alberta,CA,55.8689,-119.202
+AB744,White Sands,,Alberta,CA,52.4667,-112.817
 AB745,Whitecourt,,Alberta,CA,54.1411,-115.684
 AB746,Whitefish Lake,,Alberta,CA,55.9331,-115.369
-AB747,Whitelaw,,Alberta,CA,56.1089,-118.07600000000001
+AB747,Whitelaw,,Alberta,CA,56.1089,-118.076
 AB748,Whitla,,Alberta,CA,49.8822,-111.057
 AB749,Widewater,,Alberta,CA,55.3604,-115.037
-AB750,Wildwood,,Alberta,CA,53.6105,-115.24700000000001
+AB750,Wildwood,,Alberta,CA,53.6105,-115.247
 AB751,Willingdon,,Alberta,CA,53.8286,-112.118
-AB752,Wimborne,,Alberta,CA,51.8664,-113.59299999999999
-AB753,Winfield,,Alberta,CA,52.9653,-114.42299999999999
+AB752,Wimborne,,Alberta,CA,51.8664,-113.593
+AB753,Winfield,,Alberta,CA,52.9653,-114.423
 AB754,Winnifred,,Alberta,CA,49.9067,-111.21
 AB755,Woking,,Alberta,CA,55.5925,-118.775
-AB756,Woodbend Crescent,,Alberta,CA,53.4287,-113.73100000000001
-AB757,Woodland,,Alberta,CA,56.4863,-116.05799999999999
+AB756,Woodbend Crescent,,Alberta,CA,53.4287,-113.731
+AB757,Woodland,,Alberta,CA,56.4863,-116.058
 AB758,Woodland Hills,,Alberta,CA,52.227,-113.831
 AB759,Woodland Park,,Alberta,CA,53.4323,-113.795
 AB760,Worsley,,Alberta,CA,56.5067,-119.134
-AB761,Wrentham,,Alberta,CA,49.5144,-112.17299999999999
+AB761,Wrentham,,Alberta,CA,49.5144,-112.173
 AB762,Yellowstone,,Alberta,CA,53.7296,-114.382
 AB763,Youngstown,,Alberta,CA,51.5278,-111.2
-AB764,Zama City,,Alberta,CA,59.1537,-118.68700000000001
+AB764,Zama City,,Alberta,CA,59.1537,-118.687

--- a/vector_data/point/british_columbia_point_locations.csv
+++ b/vector_data/point/british_columbia_point_locations.csv
@@ -1,39 +1,39 @@
 id,name,alt_name,region,country,latitude,longitude
-BC1,Panorama Mountain Resort,,British Columbia,CA,50.4583,-116.23700000000001
+BC1,Panorama Mountain Resort,,British Columbia,CA,50.4583,-116.237
 BC2,Cranberry Junction,,British Columbia,CA,55.5999,-128.5395
 BC3,Deep Creek,,British Columbia,CA,50.6094,-119.213
-BC4,Donald,,British Columbia,CA,51.4958,-117.17399999999999
-BC5,Dome Creek,,British Columbia,CA,53.7425,-121.02600000000001
-BC6,Eagle Bay,,British Columbia,CA,50.9333,-119.21700000000001
+BC4,Donald,,British Columbia,CA,51.4958,-117.174
+BC5,Dome Creek,,British Columbia,CA,53.7425,-121.026
+BC6,Eagle Bay,,British Columbia,CA,50.9333,-119.217
 BC7,Old Massett,G̱aw,British Columbia,CA,54.0418,-132.184
-BC8,Progress,,British Columbia,CA,55.7817,-120.71600000000001
+BC8,Progress,,British Columbia,CA,55.7817,-120.716
 BC9,Topley Landing,,British Columbia,CA,54.8084,-126.1387
 BC10,Kobes,,British Columbia,CA,56.6389,-121.65
 BC11,Shelter Bay Ferry Terminal,,British Columbia,CA,50.6358,-117.929
-BC12,Sunnyside,,British Columbia,CA,54.6538,-124.73200000000001
-BC13,McDonalds Landing,,British Columbia,CA,54.0,-126.03299999999999
+BC12,Sunnyside,,British Columbia,CA,54.6538,-124.732
+BC13,McDonalds Landing,,British Columbia,CA,54.0,-126.033
 BC14,West Moberly,,British Columbia,CA,55.8272,-121.852
 BC15,Summit Lake,,British Columbia,CA,50.1523,-117.661
 BC16,Kelly Lake,,British Columbia,CA,51.0124,-121.7658
-BC17,Kingfisher,,British Columbia,CA,50.6167,-118.73299999999999
+BC17,Kingfisher,,British Columbia,CA,50.6167,-118.733
 BC18,Cooper Creek,,British Columbia,CA,50.2023,-116.963
 BC19,Wilson Creek,,British Columbia,CA,49.4409,-123.713
-BC20,Mica Creek,,British Columbia,CA,52.0059,-118.56200000000001
-BC21,Hall,,British Columbia,CA,49.373999999999995,-117.243
+BC20,Mica Creek,,British Columbia,CA,52.0059,-118.562
+BC21,Hall,,British Columbia,CA,49.374,-117.243
 BC22,Hyde Creek,,British Columbia,CA,50.5805,-127.0
-BC23,Bear Creek,,British Columbia,CA,49.528999999999996,-121.76100000000001
+BC23,Bear Creek,,British Columbia,CA,49.529,-121.761
 BC24,Pine Valley,,British Columbia,CA,52.1753,-122.09
-BC25,Niagara,,British Columbia,CA,49.1071,-118.46600000000001
+BC25,Niagara,,British Columbia,CA,49.1071,-118.466
 BC26,Birch Island,,British Columbia,CA,51.5971,-119.91
 BC27,Hills,,British Columbia,CA,50.1089,-117.493
 BC28,Meadows,,British Columbia,CA,49.1859,-117.396
-BC29,93 Mile,,British Columbia,CA,51.5748,-121.34100000000001
-BC30,Pineview,,British Columbia,CA,53.8367,-122.65799999999999
+BC29,93 Mile,,British Columbia,CA,51.5748,-121.341
+BC30,Pineview,,British Columbia,CA,53.8367,-122.658
 BC31,Old Fort,,British Columbia,CA,56.2022,-120.823
 BC32,Eagle Creek,,British Columbia,CA,51.8597,-120.866
 BC33,Roe Lake,,British Columbia,CA,51.5208,-120.831
 BC34,Coal Harbour,,British Columbia,CA,50.6,-127.583
-BC35,Apex Mountain Resort,,British Columbia,CA,49.3942,-119.90700000000001
+BC35,Apex Mountain Resort,,British Columbia,CA,49.3942,-119.907
 BC36,Wiley,,British Columbia,CA,54.515,-126.334
 BC37,Gilpin,,British Columbia,CA,49.0063,-118.329
 BC38,Cherry Creek,,British Columbia,CA,50.7125,-120.625
@@ -44,13 +44,13 @@ BC42,Chinook Cove,,British Columbia,CA,51.2333,-120.167
 BC43,Oliver's Landing,,British Columbia,CA,49.5833,-123.221
 BC44,Shuswap,,British Columbia,CA,50.7896,-119.709
 BC45,Rock Bay,,British Columbia,CA,50.3323,-125.486
-BC46,Stump Lake,,British Columbia,CA,50.3883,-120.32799999999999
-BC47,Cultus Lake,,British Columbia,CA,49.0714,-121.96600000000001
+BC46,Stump Lake,,British Columbia,CA,50.3883,-120.328
+BC47,Cultus Lake,,British Columbia,CA,49.0714,-121.966
 BC48,Silver Creek,,British Columbia,CA,49.3634,-121.456
 BC49,Cheslatta,,British Columbia,CA,53.8167,-125.8
 BC50,White Lake,,British Columbia,CA,50.8798,-119.302
 BC51,Mud Bay,,British Columbia,CA,49.4667,-124.8
-BC52,Lee Creek,,British Columbia,CA,50.9078,-119.53399999999999
+BC52,Lee Creek,,British Columbia,CA,50.9078,-119.534
 BC53,Six Mile Point,,British Columbia,CA,50.773,-120.7419
 BC54,Lower Kootenay,,British Columbia,CA,49.0663,-116.512
 BC55,Westview,,British Columbia,CA,49.8364,-124.525
@@ -62,37 +62,37 @@ BC60,Kettle Valley,,British Columbia,CA,49.0536,-118.945
 BC61,Davis Bay,,British Columbia,CA,49.4453,-123.726
 BC62,Arbutus Ridge,,British Columbia,CA,48.6933,-123.54
 BC63,Wet'suwet'en Village,,British Columbia,CA,54.3359,-125.89
-BC64,Upper Nicola,,British Columbia,CA,50.137,-120.27799999999999
-BC65,Dog Creek,,British Columbia,CA,52.0944,-122.11399999999999
-BC66,Nootka,,British Columbia,CA,49.6248,-126.62700000000001
+BC64,Upper Nicola,,British Columbia,CA,50.137,-120.278
+BC65,Dog Creek,,British Columbia,CA,52.0944,-122.114
+BC66,Nootka,,British Columbia,CA,49.6248,-126.627
 BC67,Kwakiutl,,British Columbia,CA,50.6931,-127.411
 BC68,Aberdeen,,British Columbia,CA,49.0503,-122.411
-BC69,Fernwood,,British Columbia,CA,48.9089,-123.52799999999999
+BC69,Fernwood,,British Columbia,CA,48.9089,-123.528
 BC70,Adams Lake,,British Columbia,CA,50.7366,-119.321
-BC71,Bonaparte,,British Columbia,CA,50.8383,-121.37799999999999
+BC71,Bonaparte,,British Columbia,CA,50.8383,-121.378
 BC72,Saik'uz,,British Columbia,CA,53.945,-124.109
-BC73,Lighthouse Point,,British Columbia,CA,48.8687,-123.28399999999999
-BC74,Lemoray,,British Columbia,CA,55.5389,-122.48299999999999
+BC73,Lighthouse Point,,British Columbia,CA,48.8687,-123.284
+BC74,Lemoray,,British Columbia,CA,55.5389,-122.483
 BC75,Squamish,,British Columbia,CA,49.3221,-123.13
 BC76,Bull River,,British Columbia,CA,49.4701,-115.448
 BC77,Cowichan Station,,British Columbia,CA,48.7294,-123.666
 BC78,Fort Babine,,British Columbia,CA,55.3223,-126.626
 BC79,Prophet River,,British Columbia,CA,58.0943,-122.71
 BC80,Cowichan,,British Columbia,CA,48.7688,-123.68
-BC81,Scotch Creek,,British Columbia,CA,50.9014,-119.45100000000001
+BC81,Scotch Creek,,British Columbia,CA,50.9014,-119.451
 BC82,Tsartlip,,British Columbia,CA,48.5856,-123.456
 BC83,Nimpkish,,British Columbia,CA,50.3333,-126.917
 BC84,Farrell Creek,,British Columbia,CA,56.1228,-121.738
-BC85,Jersey,,British Columbia,CA,49.1,-117.23299999999999
-BC86,Baker Creek,,British Columbia,CA,52.9274,-123.01700000000001
+BC85,Jersey,,British Columbia,CA,49.1,-117.233
+BC86,Baker Creek,,British Columbia,CA,52.9274,-123.017
 BC87,Klahoose,,British Columbia,CA,50.1281,-124.925
 BC88,Glenmerry,,British Columbia,CA,49.1,-117.667
 BC89,Franklin Camp,,British Columbia,CA,48.9722,-124.742
-BC90,Simpcw,,British Columbia,CA,51.2654,-120.15100000000001
+BC90,Simpcw,,British Columbia,CA,51.2654,-120.151
 BC91,Pink Mountain,,British Columbia,CA,57.0357,-122.507
 BC92,Xeni Gwet'in,,British Columbia,CA,51.4243,-124.089
-BC93,Huscroft,,British Columbia,CA,49.0167,-116.46700000000001
-BC94,Louis Creek,,British Columbia,CA,51.1401,-120.12200000000001
+BC93,Huscroft,,British Columbia,CA,49.0167,-116.467
+BC94,Louis Creek,,British Columbia,CA,51.1401,-120.122
 BC95,Commodore Heights,,British Columbia,CA,52.1667,-122.133
 BC96,Porcher Island,,British Columbia,CA,54.0867,-130.392
 BC97,Slesse Park,,British Columbia,CA,49.0805,-121.821
@@ -101,44 +101,44 @@ BC99,Osoyoos,,British Columbia,CA,49.1782,-119.527
 BC100,Garibaldi,,British Columbia,CA,49.9667,-123.15
 BC101,Doig River,,British Columbia,CA,56.5711,-120.494
 BC102,Malahat,,British Columbia,CA,48.6128,-123.523
-BC103,Coal River,,British Columbia,CA,59.65,-126.93299999999999
+BC103,Coal River,,British Columbia,CA,59.65,-126.933
 BC104,Pemberton Meadows,,British Columbia,CA,50.4417,-122.917
-BC105,Meachen,,British Columbia,CA,49.6207,-116.26700000000001
+BC105,Meachen,,British Columbia,CA,49.6207,-116.267
 BC106,Spallumcheen,,British Columbia,CA,50.5314,-119.147
 BC107,Tatla Lake,,British Columbia,CA,51.9,-124.6
 BC108,Lheidli T'enneh,,British Columbia,CA,54.0101,-122.616
 BC109,Qualicum,,British Columbia,CA,49.4,-124.617
 BC110,St. Mary's,,British Columbia,CA,49.6203,-115.696
 BC111,Uchucklesaht,,British Columbia,CA,49.0274,-125.045
-BC112,Blueberry Creek,,British Columbia,CA,49.246,-117.65899999999999
-BC113,Criss Creek,,British Columbia,CA,51.05,-120.73299999999999
+BC112,Blueberry Creek,,British Columbia,CA,49.246,-117.659
+BC113,Criss Creek,,British Columbia,CA,51.05,-120.733
 BC114,Tl'etinqox,,British Columbia,CA,52.0119,-123.1719
 BC115,Kitselas,,British Columbia,CA,54.4872,-128.586
-BC116,Toquaht,,British Columbia,CA,48.9959,-125.37899999999999
+BC116,Toquaht,,British Columbia,CA,48.9959,-125.379
 BC117,Burrard,,British Columbia,CA,49.3099,-122.978
-BC118,Eagle Heights,,British Columbia,CA,48.7563,-123.70299999999999
+BC118,Eagle Heights,,British Columbia,CA,48.7563,-123.703
 BC119,Yale,,British Columbia,CA,49.4712,-121.425
 BC120,Mount Robson,,British Columbia,CA,53.0309,-119.228
 BC121,Seton Lake,,British Columbia,CA,50.7047,-122.281
-BC122,Huu-ay-aht,,British Columbia,CA,48.8012,-125.12200000000001
+BC122,Huu-ay-aht,,British Columbia,CA,48.8012,-125.122
 BC123,Quatsino,,British Columbia,CA,50.6151,-127.574
-BC124,Cahilty,,British Columbia,CA,50.95,-120.01700000000001
-BC125,Wabi Hill,,British Columbia,CA,55.6707,-121.53200000000001
-BC126,Buckinghorse River,,British Columbia,CA,57.3901,-122.84200000000001
-BC127,Blueberry River,,British Columbia,CA,56.7035,-121.11399999999999
+BC124,Cahilty,,British Columbia,CA,50.95,-120.017
+BC125,Wabi Hill,,British Columbia,CA,55.6707,-121.532
+BC126,Buckinghorse River,,British Columbia,CA,57.3901,-122.842
+BC127,Blueberry River,,British Columbia,CA,56.7035,-121.114
 BC128,Hesquiat,,British Columbia,CA,49.3959,-126.471
-BC129,Oregon Jack Creek,,British Columbia,CA,50.6667,-121.26700000000001
-BC130,Sproat Lake,,British Columbia,CA,49.2766,-124.92399999999999
+BC129,Oregon Jack Creek,,British Columbia,CA,50.6667,-121.267
+BC130,Sproat Lake,,British Columbia,CA,49.2766,-124.924
 BC131,T'it'q'et,,British Columbia,CA,50.5833,-121.85
-BC132,Hupacasath,,British Columbia,CA,49.2657,-124.82600000000001
+BC132,Hupacasath,,British Columbia,CA,49.2657,-124.826
 BC133,Fintry,,British Columbia,CA,50.1316,-119.506
-BC134,Cape Mudge,,British Columbia,CA,50.0214,-125.29299999999999
+BC134,Cape Mudge,,British Columbia,CA,50.0214,-125.293
 BC135,Lac la Hache,,British Columbia,CA,51.8145,-121.465
 BC136,Kootenay Crossing,,British Columbia,CA,50.8833,-116.05
 BC137,Sanca,,British Columbia,CA,49.3917,-116.735
 BC138,Gambier Harbour,,British Columbia,CA,49.3728,-123.414
 BC139,Tatton,,British Columbia,CA,51.7057,-121.385
-BC140,Muncho Lake,,British Columbia,CA,58.9333,-125.76700000000001
+BC140,Muncho Lake,,British Columbia,CA,58.9333,-125.767
 BC141,Nazko,,British Columbia,CA,52.9435,-123.581
 BC142,Deka Lake,,British Columbia,CA,51.6083,-120.85
 BC143,Squeah,,British Columbia,CA,49.5042,-121.42
@@ -146,21 +146,21 @@ BC144,Telachick,,British Columbia,CA,53.8621,-123.182
 BC145,Kitselas,,British Columbia,CA,54.6167,-128.417
 BC146,Hardwicke Island,,British Columbia,CA,50.4167,-125.917
 BC147,Miocene,,British Columbia,CA,52.2503,-121.771
-BC148,Sarita,,British Columbia,CA,48.8833,-125.03299999999999
-BC149,Chezacut,,British Columbia,CA,52.3993,-124.02799999999999
+BC148,Sarita,,British Columbia,CA,48.8833,-125.033
+BC149,Chezacut,,British Columbia,CA,52.3993,-124.028
 BC150,Quesnel Forks,,British Columbia,CA,52.6564,-121.663
 BC151,Port Alice,,British Columbia,CA,50.3833,-127.45
-BC152,Tatalrose,,British Columbia,CA,53.9833,-125.98299999999999
-BC153,Coquitlam,,British Columbia,CA,49.2539,-122.84899999999999
-BC154,Hanceville,,British Columbia,CA,51.9417,-123.09899999999999
-BC155,Sullivan Bay,,British Columbia,CA,50.8833,-126.81700000000001
+BC152,Tatalrose,,British Columbia,CA,53.9833,-125.983
+BC153,Coquitlam,,British Columbia,CA,49.2539,-122.849
+BC154,Hanceville,,British Columbia,CA,51.9417,-123.099
+BC155,Sullivan Bay,,British Columbia,CA,50.8833,-126.817
 BC156,Big Bar Creek,,British Columbia,CA,51.1829,-122.117
-BC157,Lumberton,,British Columbia,CA,49.4238,-115.87700000000001
+BC157,Lumberton,,British Columbia,CA,49.4238,-115.877
 BC158,Kwaw-kwaw-Apilt,,British Columbia,CA,49.1641,-121.98
-BC159,Mahatta River,,British Columbia,CA,50.4586,-127.79799999999999
-BC160,Osborn,,British Columbia,CA,56.6042,-120.37799999999999
+BC159,Mahatta River,,British Columbia,CA,50.4586,-127.798
+BC160,Osborn,,British Columbia,CA,56.6042,-120.378
 BC161,Englishman River North,,British Columbia,CA,49.3233,-124.281
-BC162,Scowlitz,,British Columbia,CA,49.2425,-122.00200000000001
+BC162,Scowlitz,,British Columbia,CA,49.2425,-122.002
 BC163,Mount Currie,,British Columbia,CA,50.3249,-122.656
 BC164,Galena Bay,,British Columbia,CA,50.6667,-117.85
 BC165,Firvale,,British Columbia,CA,52.4385,-126.292
@@ -174,17 +174,17 @@ BC172,Mahood Falls,,British Columbia,CA,51.8426,-120.639
 BC173,Powell River,,British Columbia,CA,49.872,-124.546
 BC174,Snuneymuxw,,British Columbia,CA,49.1499,-123.929
 BC175,Sewell Inlet,,British Columbia,CA,52.8749,-131.987
-BC176,Chasm,,British Columbia,CA,51.2167,-121.48299999999999
+BC176,Chasm,,British Columbia,CA,51.2167,-121.483
 BC177,Hagensborg,,British Columbia,CA,52.3864,-126.557
 BC178,Nooaitch,,British Columbia,CA,50.1545,-121.041
 BC179,North Saanich,,British Columbia,CA,48.6217,-123.421
-BC180,Rhone,,British Columbia,CA,49.218999999999994,-119.01799999999999
-BC181,Mayook,,British Columbia,CA,49.4869,-115.57700000000001
+BC180,Rhone,,British Columbia,CA,49.219,-119.018
+BC181,Mayook,,British Columbia,CA,49.4869,-115.577
 BC182,Solsqua,,British Columbia,CA,50.8707,-118.94
 BC183,South Surrey,,British Columbia,CA,49.0543,-122.833
-BC184,Songhees,,British Columbia,CA,48.4461,-123.42200000000001
+BC184,Songhees,,British Columbia,CA,48.4461,-123.422
 BC185,Argenta,,British Columbia,CA,50.1667,-116.917
-BC186,Tatlayoko Lake,,British Columbia,CA,51.7167,-124.43299999999999
+BC186,Tatlayoko Lake,,British Columbia,CA,51.7167,-124.433
 BC187,Highlands,,British Columbia,CA,48.5144,-123.516
 BC188,Black Pines,,British Columbia,CA,50.9339,-120.258
 BC189,Summit Lake,,British Columbia,CA,54.25,-122.633
@@ -195,19 +195,19 @@ BC193,Saturna,,British Columbia,CA,48.7945,-123.195
 BC194,Lister,,British Columbia,CA,49.0474,-116.463
 BC195,Kildala Arm,,British Columbia,CA,53.8333,-128.483
 BC196,Canim Lake,,British Columbia,CA,51.7726,-120.986
-BC197,Phillips Arm,,British Columbia,CA,50.5459,-125.35600000000001
-BC198,Saanich,,British Columbia,CA,48.4878,-123.38799999999999
+BC197,Phillips Arm,,British Columbia,CA,50.5459,-125.356
+BC198,Saanich,,British Columbia,CA,48.4878,-123.388
 BC199,Bridge Lake,,British Columbia,CA,51.4786,-120.726
-BC200,Halalt,,British Columbia,CA,48.8769,-123.69200000000001
+BC200,Halalt,,British Columbia,CA,48.8769,-123.692
 BC201,Surge Narrows,,British Columbia,CA,50.2306,-125.109
 BC202,Spuzzum,,British Columbia,CA,49.6611,-121.414
-BC203,Toad River,,British Columbia,CA,58.85,-125.23299999999999
+BC203,Toad River,,British Columbia,CA,58.85,-125.233
 BC204,Punchaw,,British Columbia,CA,53.4306,-123.182
-BC205,Little Shuswap Lake,,British Columbia,CA,50.8758,-119.61200000000001
+BC205,Little Shuswap Lake,,British Columbia,CA,50.8758,-119.612
 BC206,Salmon Valley,,British Columbia,CA,54.0833,-122.7
 BC207,Read Island,,British Columbia,CA,50.1812,-125.086
 BC208,Loon Lake,,British Columbia,CA,51.0833,-121.3
-BC209,Myrtle Point,,British Columbia,CA,49.8012,-124.48100000000001
+BC209,Myrtle Point,,British Columbia,CA,49.8012,-124.481
 BC210,Barlow Creek,,British Columbia,CA,53.023,-122.445
 BC211,Charlie Lake,,British Columbia,CA,56.2974,-120.985
 BC212,Reid Lake,,British Columbia,CA,53.9667,-123.1
@@ -216,69 +216,69 @@ BC214,Popkum,,British Columbia,CA,49.2002,-121.736
 BC215,Port Moody,,British Columbia,CA,49.2786,-122.868
 BC216,Mission,,British Columbia,CA,49.1376,-122.304
 BC217,Boothroyd,,British Columbia,CA,49.9638,-121.485
-BC218,Xaxli'p,,British Columbia,CA,50.7372,-121.86200000000001
-BC219,Tulsequah,,British Columbia,CA,58.6577,-133.54399999999998
-BC220,Seabird Island,,British Columbia,CA,49.2542,-121.73100000000001
+BC218,Xaxli'p,,British Columbia,CA,50.7372,-121.862
+BC219,Tulsequah,,British Columbia,CA,58.6577,-133.544
+BC220,Seabird Island,,British Columbia,CA,49.2542,-121.731
 BC221,Ootsa Lake,,British Columbia,CA,53.8068,-126.042
 BC222,East Sooke,,British Columbia,CA,48.3645,-123.686
 BC223,Saanichton,,British Columbia,CA,48.6,-123.417
-BC224,Yreka,,British Columbia,CA,50.4638,-127.55799999999999
-BC225,Roosville,,British Columbia,CA,49.0236,-115.04700000000001
+BC224,Yreka,,British Columbia,CA,50.4638,-127.558
+BC225,Roosville,,British Columbia,CA,49.0236,-115.047
 BC226,Pacheedaht,,British Columbia,CA,48.581,-124.405
 BC227,Mud River,,British Columbia,CA,53.7612,-123.012
 BC228,Big Lake Ranch,,British Columbia,CA,52.4049,-121.876
-BC229,Ruby Creek,,British Columbia,CA,49.3468,-121.59700000000001
+BC229,Ruby Creek,,British Columbia,CA,49.3468,-121.597
 BC230,Cherry Point,,British Columbia,CA,48.7277,-123.584
-BC231,Neskonlith,,British Columbia,CA,50.7739,-119.71600000000001
+BC231,Neskonlith,,British Columbia,CA,50.7739,-119.716
 BC232,Kimsquit,,British Columbia,CA,52.8296,-126.964
 BC233,Whisky Creek,,British Columbia,CA,49.3082,-124.508
-BC234,Lindell Beach,,British Columbia,CA,49.0333,-122.01700000000001
+BC234,Lindell Beach,,British Columbia,CA,49.0333,-122.017
 BC235,Nelway,,British Columbia,CA,49.0147,-117.273
 BC236,Tchesinkut Lake,,British Columbia,CA,54.0823,-125.738
-BC237,Surrey,,British Columbia,CA,49.1745,-122.82799999999999
+BC237,Surrey,,British Columbia,CA,49.1745,-122.828
 BC238,Nulki,,British Columbia,CA,53.9185,-124.197
 BC239,Brouse,,British Columbia,CA,50.2167,-117.75
-BC240,Monte Lake,,British Columbia,CA,50.5254,-119.83200000000001
+BC240,Monte Lake,,British Columbia,CA,50.5254,-119.832
 BC241,Miworth,,British Columbia,CA,53.9399,-122.949
-BC242,Hornby Island,,British Columbia,CA,49.5227,-124.64200000000001
+BC242,Hornby Island,,British Columbia,CA,49.5227,-124.642
 BC243,Soda Creek,,British Columbia,CA,52.3466,-122.292
 BC244,Powder King,,British Columbia,CA,55.3505,-122.615
-BC245,Clearwater,,British Columbia,CA,51.65,-120.03299999999999
-BC246,Bouchie Lake,,British Columbia,CA,53.0262,-122.59700000000001
+BC245,Clearwater,,British Columbia,CA,51.65,-120.033
+BC246,Bouchie Lake,,British Columbia,CA,53.0262,-122.597
 BC247,Cayoose Creek,,British Columbia,CA,50.6721,-121.932
 BC248,Marilla,,British Columbia,CA,53.7,-125.85
 BC249,Pinchi Lake,,British Columbia,CA,54.6272,-124.404
 BC250,Stewardson Inlet,,British Columbia,CA,49.4217,-126.316
-BC251,East Pine,,British Columbia,CA,55.7167,-121.21700000000001
-BC252,Sinkut River,,British Columbia,CA,53.9538,-123.85700000000001
+BC251,East Pine,,British Columbia,CA,55.7167,-121.217
+BC252,Sinkut River,,British Columbia,CA,53.9538,-123.857
 BC253,Woodcock,,British Columbia,CA,55.0667,-128.233
-BC254,Rose Prairie,,British Columbia,CA,56.5087,-120.78299999999999
+BC254,Rose Prairie,,British Columbia,CA,56.5087,-120.783
 BC255,Qualicum Bay,,British Columbia,CA,49.4045,-124.633
 BC256,Notch Hill,,British Columbia,CA,50.8528,-119.435
-BC257,Chilliwack,,British Columbia,CA,49.175,-121.94200000000001
-BC258,Braeloch,,British Columbia,CA,49.7833,-119.51700000000001
-BC259,Prince George,,British Columbia,CA,53.9116,-122.77600000000001
+BC257,Chilliwack,,British Columbia,CA,49.175,-121.942
+BC258,Braeloch,,British Columbia,CA,49.7833,-119.517
+BC259,Prince George,,British Columbia,CA,53.9116,-122.776
 BC260,Ehatisaht,,British Columbia,CA,49.8833,-126.85
-BC261,Nukko Lake,,British Columbia,CA,54.0833,-122.98299999999999
-BC262,Premier Lake,,British Columbia,CA,49.9517,-115.65899999999999
-BC263,Westwold,,British Columbia,CA,50.4679,-119.74700000000001
+BC261,Nukko Lake,,British Columbia,CA,54.0833,-122.983
+BC262,Premier Lake,,British Columbia,CA,49.9517,-115.659
+BC263,Westwold,,British Columbia,CA,50.4679,-119.747
 BC264,Brookswood,,British Columbia,CA,49.0718,-122.666
 BC265,Birken,,British Columbia,CA,50.4833,-122.617
 BC266,Silver Creek,,British Columbia,CA,50.5961,-119.365
-BC267,Sun Peaks,,British Columbia,CA,50.878,-119.90799999999999
+BC267,Sun Peaks,,British Columbia,CA,50.878,-119.908
 BC268,Ditidaht,,British Columbia,CA,48.8091,-124.67
-BC269,Smithers Landing,,British Columbia,CA,55.053999999999995,-126.52600000000001
+BC269,Smithers Landing,,British Columbia,CA,55.054,-126.526
 BC270,Rivers Inlet,,British Columbia,CA,51.6842,-127.259
-BC271,Grassy Plains,,British Columbia,CA,53.967,-125.88799999999999
+BC271,Grassy Plains,,British Columbia,CA,53.967,-125.888
 BC272,Englishman River South,,British Columbia,CA,49.2779,-124.275
 BC273,Yaku,,British Columbia,CA,54.1923,-133.003
 BC274,Tower Lake,,British Columbia,CA,56.0155,-120.561
-BC275,Albert Head,,British Columbia,CA,48.3911,-123.50299999999999
+BC275,Albert Head,,British Columbia,CA,48.3911,-123.503
 BC276,Tlell,,British Columbia,CA,53.5667,-131.933
 BC277,North Delta,,British Columbia,CA,49.1547,-122.911
 BC278,Boat Basin,,British Columbia,CA,49.4792,-126.425
 BC279,Kluskus,,British Columbia,CA,53.0904,-124.493
-BC280,Richmond,,British Columbia,CA,49.1539,-123.15799999999999
+BC280,Richmond,,British Columbia,CA,49.1539,-123.158
 BC281,Tsawwassen,,British Columbia,CA,49.0357,-123.094
 BC282,Tahsis,,British Columbia,CA,49.9303,-126.655
 BC283,Sunset Prairie,,British Columbia,CA,55.8397,-120.764
@@ -289,9 +289,9 @@ BC287,Moberly Lake,,British Columbia,CA,55.8333,-121.758
 BC288,Holmwood,,British Columbia,CA,50.6189,-119.954
 BC289,Peachland,,British Columbia,CA,49.7786,-119.736
 BC290,Westbank,,British Columbia,CA,49.8432,-119.616
-BC291,Halfmoon Bay,,British Columbia,CA,49.5146,-123.90899999999999
+BC291,Halfmoon Bay,,British Columbia,CA,49.5146,-123.909
 BC292,Garibaldi Highlands,,British Columbia,CA,49.7417,-123.135
-BC293,Williams Beach,,British Columbia,CA,49.833999999999996,-125.061
+BC293,Williams Beach,,British Columbia,CA,49.834,-125.061
 BC294,Crowsnest,,British Columbia,CA,49.6368,-114.695
 BC295,Fosthall,,British Columbia,CA,50.3488,-117.935
 BC296,Nemaiah Valley,,British Columbia,CA,51.4776,-123.887
@@ -301,43 +301,43 @@ BC299,Blue River,,British Columbia,CA,52.1061,-119.306
 BC300,Aldergrove,,British Columbia,CA,49.0576,-122.471
 BC301,Penticton,,British Columbia,CA,49.4822,-119.585
 BC302,Upper Fraser,,British Columbia,CA,54.1082,-121.931
-BC303,Foreman,,British Columbia,CA,53.95,-122.68299999999999
-BC304,Kersley,,British Columbia,CA,52.8358,-122.41799999999999
+BC303,Foreman,,British Columbia,CA,53.95,-122.683
+BC304,Kersley,,British Columbia,CA,52.8358,-122.418
 BC305,Upper Halfway,,British Columbia,CA,56.5176,-122.226
 BC306,Shackan,,British Columbia,CA,50.284,-121.178
-BC307,Health Bay,,British Columbia,CA,50.6939,-126.59700000000001
-BC308,Denman Island,,British Columbia,CA,49.5358,-124.81299999999999
+BC307,Health Bay,,British Columbia,CA,50.6939,-126.597
+BC308,Denman Island,,British Columbia,CA,49.5358,-124.813
 BC309,Port Coquitlam,,British Columbia,CA,49.2567,-122.762
 BC310,Elkford,,British Columbia,CA,50.0123,-114.93
 BC311,Valleyview,,British Columbia,CA,50.6738,-120.25
 BC312,McLure,,British Columbia,CA,51.0539,-120.225
-BC313,Riske Creek,,British Columbia,CA,51.9596,-122.51799999999999
+BC313,Riske Creek,,British Columbia,CA,51.9596,-122.518
 BC314,Cedar,,British Columbia,CA,49.1043,-123.854
 BC315,Rogers Pass,,British Columbia,CA,51.3009,-117.521
 BC316,Shawl Bay,,British Columbia,CA,50.8433,-126.56
 BC317,Cloverdale,,British Columbia,CA,49.1117,-122.725
 BC318,Dugan Lake,,British Columbia,CA,52.1667,-121.925
 BC319,Cobble Hill,,British Columbia,CA,48.6915,-123.585
-BC320,Shuswap,,British Columbia,CA,50.5268,-116.00200000000001
+BC320,Shuswap,,British Columbia,CA,50.5268,-116.002
 BC321,Saseenos,,British Columbia,CA,48.3908,-123.669
-BC322,Pritchard,,British Columbia,CA,50.6851,-119.81200000000001
-BC323,Oweekeno,,British Columbia,CA,51.6853,-127.20700000000001
+BC322,Pritchard,,British Columbia,CA,50.6851,-119.812
+BC323,Oweekeno,,British Columbia,CA,51.6853,-127.207
 BC324,Old Fort,,British Columbia,CA,55.0376,-126.318
 BC325,Gang Ranch,,British Columbia,CA,51.5538,-122.351
-BC326,Williams Lake,,British Columbia,CA,52.1415,-122.14299999999999
+BC326,Williams Lake,,British Columbia,CA,52.1415,-122.143
 BC327,View Royal,,British Columbia,CA,48.4583,-123.45
 BC328,Hot Springs Cove,,British Columbia,CA,49.352,-126.26
 BC329,Shalalth,,British Columbia,CA,50.7294,-122.215
 BC330,Winfield,,British Columbia,CA,50.0333,-119.402
 BC331,Tatogga,,British Columbia,CA,57.7163,-129.987
-BC332,Ucluelet,,British Columbia,CA,48.9399,-125.52799999999999
-BC333,Fanny Bay,,British Columbia,CA,49.4901,-124.81299999999999
+BC332,Ucluelet,,British Columbia,CA,48.9399,-125.528
+BC333,Fanny Bay,,British Columbia,CA,49.4901,-124.813
 BC334,South Wellington,,British Columbia,CA,49.0941,-123.887
-BC335,Yahk,,British Columbia,CA,49.085,-116.08200000000001
+BC335,Yahk,,British Columbia,CA,49.085,-116.082
 BC336,Musqueam,,British Columbia,CA,49.2298,-123.2
 BC337,Oona River,,British Columbia,CA,53.9469,-130.256
 BC338,Walnut Grove,,British Columbia,CA,49.1806,-122.648
-BC339,Okanagan Mission,,British Columbia,CA,49.8167,-119.48299999999999
+BC339,Okanagan Mission,,British Columbia,CA,49.8167,-119.483
 BC340,Bob Quinn Lake,,British Columbia,CA,56.9722,-130.247
 BC341,Fort Rupert,,British Columbia,CA,50.6889,-127.42
 BC342,Boswell,,British Columbia,CA,49.4503,-116.764
@@ -346,47 +346,47 @@ BC344,Blowhole,,British Columbia,CA,49.8292,-126.676
 BC345,Burnaby,,British Columbia,CA,49.2521,-122.962
 BC346,Mackenzie,,British Columbia,CA,55.3353,-123.096
 BC347,Ogden,,British Columbia,CA,50.7819,-122.822
-BC348,Parksville,,British Columbia,CA,49.3227,-124.32700000000001
+BC348,Parksville,,British Columbia,CA,49.3227,-124.327
 BC349,Port Renfrew,,British Columbia,CA,48.5574,-124.405
 BC350,Chetwynd,,British Columbia,CA,55.6949,-121.619
-BC351,Wasa,,British Columbia,CA,49.7833,-115.73299999999999
-BC352,Alice Arm,,British Columbia,CA,55.4728,-129.47799999999998
+BC351,Wasa,,British Columbia,CA,49.7833,-115.733
+BC352,Alice Arm,,British Columbia,CA,55.4728,-129.478
 BC353,New Westminster,,British Columbia,CA,49.2167,-122.917
-BC354,Blaeberry,,British Columbia,CA,51.4333,-117.06700000000001
-BC355,Shutty Bench,,British Columbia,CA,49.9629,-116.90700000000001
-BC356,Pope Landing,,British Columbia,CA,49.6145,-124.04799999999999
+BC354,Blaeberry,,British Columbia,CA,51.4333,-117.067
+BC355,Shutty Bench,,British Columbia,CA,49.9629,-116.907
+BC356,Pope Landing,,British Columbia,CA,49.6145,-124.048
 BC357,Quatsino,,British Columbia,CA,50.5357,-127.652
 BC358,Fair Harbour,,British Columbia,CA,50.0565,-127.101
 BC359,Butedale,,British Columbia,CA,53.15,-128.7
 BC360,Lang Bay,,British Columbia,CA,49.7792,-124.346
 BC361,Yarksis,,British Columbia,CA,49.1654,-125.971
-BC362,Gray Creek,,British Columbia,CA,49.6333,-116.78299999999999
+BC362,Gray Creek,,British Columbia,CA,49.6333,-116.783
 BC363,Vedder Crossing,,British Columbia,CA,49.1062,-121.971
 BC364,Vidette,,British Columbia,CA,51.1667,-120.9
 BC365,Takysie Lake,,British Columbia,CA,53.8833,-125.867
-BC366,Kedleston,,British Columbia,CA,50.3167,-119.18299999999999
-BC367,Buckley Bay,,British Columbia,CA,49.5333,-124.85700000000001
+BC366,Kedleston,,British Columbia,CA,50.3167,-119.183
+BC367,Buckley Bay,,British Columbia,CA,49.5333,-124.857
 BC368,Isle Pierre,,British Columbia,CA,53.95,-123.25
 BC369,Seton Portage,,British Columbia,CA,50.7069,-122.289
-BC370,Aleza Lake,,British Columbia,CA,54.1143,-122.03399999999999
+BC370,Aleza Lake,,British Columbia,CA,54.1143,-122.034
 BC371,Blind Bay,,British Columbia,CA,50.8833,-119.383
 BC372,Cherry Creek,,British Columbia,CA,49.2827,-124.787
-BC373,Pauquachin,,British Columbia,CA,48.6204,-123.45299999999999
+BC373,Pauquachin,,British Columbia,CA,48.6204,-123.453
 BC374,Donald Landing,,British Columbia,CA,54.4833,-125.65
 BC375,Headquarters,,British Columbia,CA,49.7646,-125.115
 BC376,Belcarra,,British Columbia,CA,49.3182,-122.928
 BC377,Ceepeecee,,British Columbia,CA,49.8732,-126.711
 BC378,Seymour Arm,,British Columbia,CA,51.2484,-118.94
-BC379,Cheam,,British Columbia,CA,49.1942,-121.77600000000001
+BC379,Cheam,,British Columbia,CA,49.1942,-121.776
 BC380,Sandspit,,British Columbia,CA,53.2479,-131.814
-BC381,Kelowna,,British Columbia,CA,49.8833,-119.48299999999999
+BC381,Kelowna,,British Columbia,CA,49.8833,-119.483
 BC382,Valemount,,British Columbia,CA,52.8305,-119.265
-BC383,Secret Cove,,British Columbia,CA,49.5363,-123.95200000000001
+BC383,Secret Cove,,British Columbia,CA,49.5363,-123.952
 BC384,Winlaw,,British Columbia,CA,49.6144,-117.55
 BC385,Fort Ware,,British Columbia,CA,57.4252,-125.633
 BC386,Dashwood,,British Columbia,CA,49.3621,-124.506
-BC387,Estevan Point,,British Columbia,CA,49.3782,-126.53399999999999
-BC388,Grand Forks,,British Columbia,CA,49.028999999999996,-118.45299999999999
+BC387,Estevan Point,,British Columbia,CA,49.3782,-126.534
+BC388,Grand Forks,,British Columbia,CA,49.029,-118.453
 BC389,Williamsons Landing,,British Columbia,CA,49.4497,-123.469
 BC390,Cinnabar Valley,,British Columbia,CA,49.1033,-123.926
 BC391,Bull Harbour,,British Columbia,CA,50.9177,-127.931
@@ -395,60 +395,60 @@ BC393,Brem River,,British Columbia,CA,50.4392,-124.671
 BC394,Granite Bay,,British Columbia,CA,50.2333,-125.3
 BC395,Princeton,,British Columbia,CA,49.4524,-120.514
 BC396,Yankee Flats,,British Columbia,CA,50.5164,-119.375
-BC397,Gravelle Ferry,,British Columbia,CA,52.85,-122.23299999999999
-BC398,Colwood,,British Columbia,CA,48.4321,-123.49700000000001
+BC397,Gravelle Ferry,,British Columbia,CA,52.85,-122.233
+BC398,Colwood,,British Columbia,CA,48.4321,-123.497
 BC399,Glenrosa,,British Columbia,CA,49.8472,-119.667
 BC400,Westside,,British Columbia,CA,49.8822,-119.535
-BC401,Alkali Lake,,British Columbia,CA,51.788000000000004,-122.227
+BC401,Alkali Lake,,British Columbia,CA,51.788,-122.227
 BC402,Mansons Landing,,British Columbia,CA,50.0581,-124.98
 BC403,Moha,,British Columbia,CA,50.8641,-122.17
 BC404,Owen Bay,,British Columbia,CA,50.3169,-125.214
 BC405,Springhouse,,British Columbia,CA,51.9667,-122.133
-BC406,McKearney Ranch,,British Columbia,CA,56.6333,-122.46700000000001
+BC406,McKearney Ranch,,British Columbia,CA,56.6333,-122.467
 BC407,Kanaka Bar,,British Columbia,CA,50.1127,-121.561
 BC408,Midway,,British Columbia,CA,49.0071,-118.773
 BC409,108 Mile Ranch,,British Columbia,CA,51.7281,-121.351
 BC410,Bloedel,,British Columbia,CA,50.1167,-125.383
-BC411,Round Lake,,British Columbia,CA,54.6648,-126.92299999999999
-BC412,Langford,,British Columbia,CA,48.4566,-123.49700000000001
+BC411,Round Lake,,British Columbia,CA,54.6648,-126.923
+BC412,Langford,,British Columbia,CA,48.4566,-123.497
 BC413,Beaverley,,British Columbia,CA,53.8172,-122.881
-BC414,Arras,,British Columbia,CA,55.7535,-120.52600000000001
+BC414,Arras,,British Columbia,CA,55.7535,-120.526
 BC415,Sion,,British Columbia,CA,49.0207,-118.484
 BC416,Trail,,British Columbia,CA,49.1,-117.7
 BC417,Shuswap Falls,,British Columbia,CA,50.294,-118.805
 BC418,Cedarside,,British Columbia,CA,52.7823,-119.25
 BC419,Port Alberni,,British Columbia,CA,49.2417,-124.8
-BC420,Brew Bay,,British Columbia,CA,49.7758,-124.37100000000001
+BC420,Brew Bay,,British Columbia,CA,49.7758,-124.371
 BC421,Port Hardy,,British Columbia,CA,50.7189,-127.507
-BC422,Goose Bay,,British Columbia,CA,51.38,-127.65700000000001
+BC422,Goose Bay,,British Columbia,CA,51.38,-127.657
 BC423,Mooyah Bay,,British Columbia,CA,49.6295,-126.458
 BC424,Iskut,,British Columbia,CA,57.8466,-129.983
 BC425,Kootenay Bay,,British Columbia,CA,49.6849,-116.866
-BC426,Fireside,,British Columbia,CA,59.6705,-127.13600000000001
+BC426,Fireside,,British Columbia,CA,59.6705,-127.136
 BC427,Christian Valley,,British Columbia,CA,49.5513,-118.802
-BC428,Vermilion Crossing,,British Columbia,CA,51.0333,-115.98299999999999
+BC428,Vermilion Crossing,,British Columbia,CA,51.0333,-115.983
 BC429,Deer Park,,British Columbia,CA,49.4167,-118.05
 BC430,Chilanko Forks,,British Columbia,CA,52.1199,-124.061
-BC431,Heydon Bay,,British Columbia,CA,50.5781,-125.57600000000001
-BC432,North Vancouver,,British Columbia,CA,49.3142,-123.06700000000001
+BC431,Heydon Bay,,British Columbia,CA,50.5781,-125.576
+BC432,North Vancouver,,British Columbia,CA,49.3142,-123.067
 BC433,Crescent Spur,,British Columbia,CA,53.5717,-120.695
-BC434,Minstrel Island,,British Columbia,CA,50.6154,-126.30799999999999
+BC434,Minstrel Island,,British Columbia,CA,50.6154,-126.308
 BC435,Eddontenajon,,British Columbia,CA,57.8221,-129.958
 BC436,Pinchi,,British Columbia,CA,54.5706,-124.493
-BC437,Attachie,,British Columbia,CA,56.2205,-121.42299999999999
-BC438,Black Point,,British Columbia,CA,49.773999999999994,-124.39399999999999
-BC439,Salmon Arm,,British Columbia,CA,50.7,-119.26700000000001
+BC437,Attachie,,British Columbia,CA,56.2205,-121.423
+BC438,Black Point,,British Columbia,CA,49.774,-124.394
+BC439,Salmon Arm,,British Columbia,CA,50.7,-119.267
 BC440,Anglemont,,British Columbia,CA,50.9667,-119.167
 BC441,Decker Lake,,British Columbia,CA,54.3,-125.833
 BC442,New Aiyansh,,British Columbia,CA,55.2003,-129.072
 BC443,Atlin,,British Columbia,CA,59.5679,-133.697
 BC444,Fort Fraser,,British Columbia,CA,54.06,-124.55
-BC445,Nak'azdli,,British Columbia,CA,54.4309,-124.24799999999999
-BC446,Balfour,,British Columbia,CA,49.6283,-116.97200000000001
+BC445,Nak'azdli,,British Columbia,CA,54.4309,-124.248
+BC446,Balfour,,British Columbia,CA,49.6283,-116.972
 BC447,Kitseguecla,,British Columbia,CA,55.0857,-127.818
-BC448,Sandon,,British Columbia,CA,49.9833,-117.23299999999999
+BC448,Sandon,,British Columbia,CA,49.9833,-117.233
 BC449,Hope,,British Columbia,CA,49.3802,-121.43
-BC450,Ferguson,,British Columbia,CA,50.6833,-117.48299999999999
+BC450,Ferguson,,British Columbia,CA,50.6833,-117.483
 BC451,Holberg,,British Columbia,CA,50.6623,-128.011
 BC452,Sechelt,,British Columbia,CA,49.4794,-123.762
 BC453,Skidegate,,British Columbia,CA,53.2715,-131.988
@@ -457,19 +457,19 @@ BC455,Namgis,,British Columbia,CA,50.5919,-126.944
 BC456,Barriere,,British Columbia,CA,51.1819,-120.133
 BC457,Tumbler Ridge,,British Columbia,CA,55.1333,-121.0
 BC458,Cranbrook,,British Columbia,CA,49.5155,-115.759
-BC459,Hudson's Hope,,British Columbia,CA,56.0319,-121.90700000000001
+BC459,Hudson's Hope,,British Columbia,CA,56.0319,-121.907
 BC460,Horseshoe Bay,,British Columbia,CA,49.3674,-123.273
 BC461,Saltair,,British Columbia,CA,48.9571,-123.774
 BC462,Shulus,,British Columbia,CA,50.1373,-120.853
 BC463,Boring Ranch,,British Columbia,CA,56.95,-122.7
-BC464,Gillies Bay,,British Columbia,CA,49.6833,-124.48299999999999
-BC465,Renata,,British Columbia,CA,49.4268,-118.10700000000001
+BC464,Gillies Bay,,British Columbia,CA,49.6833,-124.483
+BC465,Renata,,British Columbia,CA,49.4268,-118.107
 BC466,Colleymount,,British Columbia,CA,54.0333,-126.15
 BC467,Dawsons Landing,,British Columbia,CA,51.5805,-127.586
-BC468,Hilliers,,British Columbia,CA,49.3068,-124.48299999999999
+BC468,Hilliers,,British Columbia,CA,49.3068,-124.483
 BC469,Clairmont,,British Columbia,CA,56.2559,-120.9
-BC470,Summerland,,British Columbia,CA,49.6054,-119.67299999999999
-BC471,Tintagel,,British Columbia,CA,54.2029,-125.59299999999999
+BC470,Summerland,,British Columbia,CA,49.6054,-119.673
+BC471,Tintagel,,British Columbia,CA,54.2029,-125.593
 BC472,Heriot Bay,,British Columbia,CA,50.1002,-125.213
 BC473,Mitchell Bay,,British Columbia,CA,50.6333,-126.85
 BC474,Smithers,,British Columbia,CA,54.7825,-127.166
@@ -477,10 +477,10 @@ BC475,Genelle,,British Columbia,CA,49.2139,-117.691
 BC476,Twidwell Bend,,British Columbia,CA,55.6155,-121.571
 BC477,Oak Bay,,British Columbia,CA,48.4301,-123.309
 BC478,Middle River,,British Columbia,CA,54.8761,-125.13
-BC479,Lone Butte,,British Columbia,CA,51.5579,-121.21600000000001
+BC479,Lone Butte,,British Columbia,CA,51.5579,-121.216
 BC480,Yekooche,,British Columbia,CA,54.5992,-125.072
 BC481,Prince Rupert,,British Columbia,CA,54.315,-130.315
-BC482,Baldy Hughes,,British Columbia,CA,53.6246,-122.93299999999999
+BC482,Baldy Hughes,,British Columbia,CA,53.6246,-122.933
 BC483,Nanoose Bay,,British Columbia,CA,49.2667,-124.2
 BC484,Quathiaski Cove,,British Columbia,CA,50.0454,-125.21
 BC485,Whistler,,British Columbia,CA,50.1215,-122.962
@@ -489,57 +489,57 @@ BC487,Madeira Park,,British Columbia,CA,49.6157,-124.02
 BC488,Campbell River,,British Columbia,CA,50.0167,-125.242
 BC489,Woss,,British Columbia,CA,50.2167,-126.6
 BC490,Invermere,,British Columbia,CA,50.5007,-116.038
-BC491,Darfield,,British Columbia,CA,51.3,-120.18299999999999
+BC491,Darfield,,British Columbia,CA,51.3,-120.183
 BC492,Deroche,,British Columbia,CA,49.1914,-122.081
 BC493,Fort St. John,,British Columbia,CA,56.2461,-120.845
-BC494,Cecil Lake,,British Columbia,CA,56.306000000000004,-120.57700000000001
-BC495,Quesnel,,British Columbia,CA,52.9806,-122.50399999999999
+BC494,Cecil Lake,,British Columbia,CA,56.306,-120.577
+BC495,Quesnel,,British Columbia,CA,52.9806,-122.504
 BC496,Osland,,British Columbia,CA,54.1333,-130.167
-BC497,Manson Creek,,British Columbia,CA,55.6667,-124.48299999999999
+BC497,Manson Creek,,British Columbia,CA,55.6667,-124.483
 BC498,Pemberton,,British Columbia,CA,50.3167,-122.8
-BC499,Penny,,British Columbia,CA,53.8474,-121.28399999999999
-BC500,Canal Flats,,British Columbia,CA,50.1576,-115.81700000000001
-BC501,Carmi,,British Columbia,CA,49.5009,-119.12200000000001
-BC502,Kemano,,British Columbia,CA,53.5573,-127.93299999999999
+BC499,Penny,,British Columbia,CA,53.8474,-121.284
+BC500,Canal Flats,,British Columbia,CA,50.1576,-115.817
+BC501,Carmi,,British Columbia,CA,49.5009,-119.122
+BC502,Kemano,,British Columbia,CA,53.5573,-127.933
 BC503,Erie,,British Columbia,CA,49.1912,-117.337
 BC504,Cowichan Bay,,British Columbia,CA,48.7371,-123.62
 BC505,Broman Lake,,British Columbia,CA,54.4203,-126.135
 BC506,Murrayville,,British Columbia,CA,49.0904,-122.616
 BC507,Coldwater,,British Columbia,CA,50.0358,-120.859
-BC508,Terrace,,British Columbia,CA,54.5234,-128.59799999999998
+BC508,Terrace,,British Columbia,CA,54.5234,-128.598
 BC509,Mill Bay,,British Columbia,CA,48.6449,-123.556
-BC510,Whaletown,,British Columbia,CA,50.1012,-125.04700000000001
+BC510,Whaletown,,British Columbia,CA,50.1012,-125.047
 BC511,Taylor,,British Columbia,CA,56.1544,-120.68
 BC512,Weewanie,,British Columbia,CA,53.6917,-128.79
 BC513,Castlegar,,British Columbia,CA,49.3218,-117.66
-BC514,Kleena Kleene,,British Columbia,CA,51.9504,-124.84700000000001
+BC514,Kleena Kleene,,British Columbia,CA,51.9504,-124.847
 BC515,Woodsdale,,British Columbia,CA,50.0495,-119.39
-BC516,Manning Park,,British Columbia,CA,49.0668,-120.78200000000001
+BC516,Manning Park,,British Columbia,CA,49.0668,-120.782
 BC517,Fern Ridge,,British Columbia,CA,49.0483,-122.656
 BC518,Kamloops,,British Columbia,CA,50.6783,-120.348
-BC519,Wilson Landing,,British Columbia,CA,49.9821,-119.49700000000001
+BC519,Wilson Landing,,British Columbia,CA,49.9821,-119.497
 BC520,Caycuse,,British Columbia,CA,48.8943,-124.366
 BC521,McLeese Lake,,British Columbia,CA,52.4137,-122.296
 BC522,Grantham,,British Columbia,CA,49.7628,-125.021
 BC523,Beatton Ranch,,British Columbia,CA,56.7333,-122.583
-BC524,Fauquier,,British Columbia,CA,49.8667,-118.06700000000001
-BC525,Oyster River,,British Columbia,CA,49.8738,-125.12899999999999
+BC524,Fauquier,,British Columbia,CA,49.8667,-118.067
+BC525,Oyster River,,British Columbia,CA,49.8738,-125.129
 BC526,Kuskonook,,British Columbia,CA,49.3,-116.65
-BC527,Nicholson,,British Columbia,CA,51.2481,-116.90100000000001
-BC528,Sunningdale,,British Columbia,CA,49.1167,-117.71700000000001
-BC529,Nelson,,British Columbia,CA,49.4975,-117.28200000000001
+BC527,Nicholson,,British Columbia,CA,51.2481,-116.901
+BC528,Sunningdale,,British Columbia,CA,49.1167,-117.717
+BC529,Nelson,,British Columbia,CA,49.4975,-117.282
 BC530,Chamiss Bay,,British Columbia,CA,50.0694,-127.287
-BC531,Ladner,,British Columbia,CA,49.0917,-123.07799999999999
-BC532,Tseshaht,,British Columbia,CA,49.268,-124.85799999999999
+BC531,Ladner,,British Columbia,CA,49.0917,-123.078
+BC532,Tseshaht,,British Columbia,CA,49.268,-124.858
 BC533,Metchosin,,British Columbia,CA,48.3756,-123.529
 BC534,Saratoga Beach,,British Columbia,CA,49.8595,-125.116
 BC535,Boston Bar,,British Columbia,CA,49.8624,-121.443
-BC536,Skuppah,,British Columbia,CA,50.1885,-121.57799999999999
+BC536,Skuppah,,British Columbia,CA,50.1885,-121.578
 BC537,Bamfield,,British Columbia,CA,48.8312,-125.133
-BC538,Anmore,,British Columbia,CA,49.3115,-122.84899999999999
+BC538,Anmore,,British Columbia,CA,49.3115,-122.849
 BC539,Snug Cove,,British Columbia,CA,49.3829,-123.336
-BC540,Wadhams,,British Columbia,CA,51.5171,-127.51899999999999
-BC541,Brisco,,British Columbia,CA,50.8333,-116.26700000000001
+BC540,Wadhams,,British Columbia,CA,51.5171,-127.519
+BC541,Brisco,,British Columbia,CA,50.8333,-116.267
 BC542,Buick,,British Columbia,CA,56.7625,-121.27
 BC543,Hartley Bay,,British Columbia,CA,53.4203,-129.256
 BC544,Ranchero,,British Columbia,CA,50.657,-119.198
@@ -551,36 +551,36 @@ BC549,Cedarvale,,British Columbia,CA,55.0194,-128.329
 BC550,Homalco,,British Columbia,CA,49.9526,-125.243
 BC551,Brentwood Bay,,British Columbia,CA,48.5683,-123.456
 BC552,Tzeachten,,British Columbia,CA,49.115,-121.939
-BC553,Victoria,,British Columbia,CA,48.4334,-123.36200000000001
+BC553,Victoria,,British Columbia,CA,48.4334,-123.362
 BC554,Moresby Camp,,British Columbia,CA,53.0475,-132.029
 BC555,Roberts Creek,,British Columbia,CA,49.426,-123.646
-BC556,Lantzville,,British Columbia,CA,49.2532,-124.08200000000001
+BC556,Lantzville,,British Columbia,CA,49.2532,-124.082
 BC557,Greenwood,,British Columbia,CA,49.0949,-118.676
 BC558,Stewart,,British Columbia,CA,55.9418,-129.984
-BC559,Takla Landing,,British Columbia,CA,55.483000000000004,-125.97399999999999
+BC559,Takla Landing,,British Columbia,CA,55.483,-125.974
 BC560,70 Mile House,,British Columbia,CA,51.3084,-121.396
-BC561,Windermere,,British Columbia,CA,50.4667,-115.98299999999999
+BC561,Windermere,,British Columbia,CA,50.4667,-115.983
 BC562,Perow,,British Columbia,CA,54.5202,-126.44
 BC563,Yuquot,,British Columbia,CA,49.5957,-126.624
-BC564,Sinclair Mills,,British Columbia,CA,54.0167,-121.68299999999999
+BC564,Sinclair Mills,,British Columbia,CA,54.0167,-121.683
 BC565,Retallack,,British Columbia,CA,50.0414,-117.14
-BC566,Cumberland,,British Columbia,CA,49.622,-125.02600000000001
+BC566,Cumberland,,British Columbia,CA,49.622,-125.026
 BC567,Dolphin Beach,,British Columbia,CA,49.2884,-124.147
 BC568,Creston,,British Columbia,CA,49.1006,-116.507
-BC569,Baynes Lake,,British Columbia,CA,49.2333,-115.21700000000001
+BC569,Baynes Lake,,British Columbia,CA,49.2333,-115.217
 BC570,Lower Post,,British Columbia,CA,59.9249,-128.486
-BC571,Skookumchuck,,British Columbia,CA,49.943000000000005,-122.40799999999999
+BC571,Skookumchuck,,British Columbia,CA,49.943,-122.408
 BC572,Harrison Mills,,British Columbia,CA,49.2559,-121.949
-BC573,Langley,,British Columbia,CA,49.1038,-122.65899999999999
+BC573,Langley,,British Columbia,CA,49.1038,-122.659
 BC574,Gold Bridge,,British Columbia,CA,50.85,-122.833
 BC575,Monte Creek,,British Columbia,CA,50.6487,-119.958
-BC576,Marktosis,,British Columbia,CA,49.2786,-126.05799999999999
-BC577,Masset,,British Columbia,CA,54.0174,-132.14700000000002
+BC576,Marktosis,,British Columbia,CA,49.2786,-126.058
+BC577,Masset,,British Columbia,CA,54.0174,-132.147
 BC578,Sturdies Bay,,British Columbia,CA,48.8792,-123.319
 BC579,Telegraph Creek,,British Columbia,CA,57.9018,-131.166
 BC580,Shelter Point,,British Columbia,CA,49.9403,-125.191
 BC581,Westmount,,British Columbia,CA,49.3439,-123.209
-BC582,McLeod Lake,,British Columbia,CA,54.985,-123.04700000000001
+BC582,McLeod Lake,,British Columbia,CA,54.985,-123.047
 BC583,Nass Camp,,British Columbia,CA,55.2884,-129.006
 BC584,Alert Bay,,British Columbia,CA,50.5789,-126.92
 BC585,Ganges,,British Columbia,CA,48.8599,-123.507
@@ -589,27 +589,27 @@ BC587,Van Anda,,British Columbia,CA,49.7583,-124.55
 BC588,Sumas,,British Columbia,CA,49.0531,-122.193
 BC589,McDame,,British Columbia,CA,59.1856,-129.225
 BC590,West Popkum,,British Columbia,CA,49.1822,-121.773
-BC591,Simpson Ranch,,British Columbia,CA,56.6,-122.43299999999999
+BC591,Simpson Ranch,,British Columbia,CA,56.6,-122.433
 BC592,Shelley,,British Columbia,CA,54.0,-122.617
 BC593,River Jordan,,British Columbia,CA,48.4221,-124.05
-BC594,D'Arcy,,British Columbia,CA,50.55,-122.48299999999999
+BC594,D'Arcy,,British Columbia,CA,50.55,-122.483
 BC595,Lax Kw'alaams,,British Columbia,CA,54.55,-130.433
 BC596,Fernie,,British Columbia,CA,49.5068,-115.069
-BC597,Sayward,,British Columbia,CA,50.376999999999995,-125.95200000000001
+BC597,Sayward,,British Columbia,CA,50.377,-125.952
 BC598,Harrop,,British Columbia,CA,49.6016,-117.053
-BC599,Field,,British Columbia,CA,51.3945,-116.48200000000001
+BC599,Field,,British Columbia,CA,51.3945,-116.482
 BC600,Tuwanek,,British Columbia,CA,49.5442,-123.757
-BC601,Blackwater,,British Columbia,CA,53.2875,-123.15100000000001
-BC602,Lower Nicola,,British Columbia,CA,50.1597,-120.87799999999999
+BC601,Blackwater,,British Columbia,CA,53.2875,-123.151
+BC602,Lower Nicola,,British Columbia,CA,50.1597,-120.878
 BC603,Big Bay,,British Columbia,CA,50.3972,-125.135
 BC604,Elk Bay,,British Columbia,CA,50.2856,-125.436
 BC605,Lac Le Jeune,,British Columbia,CA,50.4817,-120.493
-BC606,Fairmont Hot Springs,,British Columbia,CA,50.3349,-115.85600000000001
+BC606,Fairmont Hot Springs,,British Columbia,CA,50.3349,-115.856
 BC607,Douglas,,British Columbia,CA,49.0028,-122.736
-BC608,Zeballos,,British Columbia,CA,49.986999999999995,-126.84700000000001
+BC608,Zeballos,,British Columbia,CA,49.987,-126.847
 BC609,Juskatla,,British Columbia,CA,53.6102,-132.311
 BC610,Little River,,British Columbia,CA,49.7377,-124.914
-BC611,Port McNeill,,British Columbia,CA,50.586000000000006,-127.079
+BC611,Port McNeill,,British Columbia,CA,50.586,-127.079
 BC612,Fort St. James,,British Columbia,CA,54.4487,-124.256
 BC613,McBride,,British Columbia,CA,53.3,-120.167
 BC614,Bennett,,British Columbia,CA,59.8451,-134.987
@@ -618,76 +618,76 @@ BC616,Enderby,,British Columbia,CA,50.5549,-119.141
 BC617,Pitt Meadows,,British Columbia,CA,49.2172,-122.686
 BC618,Farmington,,British Columbia,CA,55.9,-120.5
 BC619,Sliammon,,British Columbia,CA,49.8962,-124.601
-BC620,Klemtu,,British Columbia,CA,52.5904,-128.52700000000002
+BC620,Klemtu,,British Columbia,CA,52.5904,-128.527
 BC621,Chemainus,,British Columbia,CA,48.9266,-123.721
 BC622,Earls Cove,,British Columbia,CA,49.75,-124.0
 BC623,Granisle,,British Columbia,CA,54.8844,-126.213
 BC624,Delkatla,,British Columbia,CA,54.0086,-132.129
 BC625,Edgewood,,British Columbia,CA,49.7833,-118.15
 BC626,Kaslo,,British Columbia,CA,49.9086,-116.911
-BC627,Metlakatla,,British Columbia,CA,54.3375,-130.44299999999998
+BC627,Metlakatla,,British Columbia,CA,54.3375,-130.443
 BC628,Allison Lake,,British Columbia,CA,49.6889,-120.601
 BC629,Port Washington,,British Columbia,CA,48.8166,-123.321
 BC630,Black Creek,,British Columbia,CA,49.8369,-125.132
 BC631,Usk,,British Columbia,CA,54.6333,-128.417
 BC632,Duck Range,,British Columbia,CA,50.6192,-119.83
 BC633,Namu,,British Columbia,CA,51.8613,-127.86
-BC634,Hasler Flat,,British Columbia,CA,55.6111,-121.96700000000001
+BC634,Hasler Flat,,British Columbia,CA,55.6111,-121.967
 BC635,Cranberry,,British Columbia,CA,49.8702,-124.523
 BC636,Snake River,,British Columbia,CA,59.0364,-122.439
-BC637,Cherryville,,British Columbia,CA,50.2407,-118.62100000000001
+BC637,Cherryville,,British Columbia,CA,50.2407,-118.621
 BC638,Remo,,British Columbia,CA,54.5007,-128.719
 BC639,Kingcome,,British Columbia,CA,50.9742,-126.175
 BC640,Giscome,,British Columbia,CA,54.0667,-122.367
-BC641,Two Mile,,British Columbia,CA,55.2687,-127.62700000000001
-BC642,Hunts Inlet,,British Columbia,CA,54.0668,-130.44299999999998
+BC641,Two Mile,,British Columbia,CA,55.2687,-127.627
+BC642,Hunts Inlet,,British Columbia,CA,54.0668,-130.443
 BC643,Robson,,British Columbia,CA,49.3375,-117.691
-BC644,Willow River,,British Columbia,CA,54.0787,-122.47399999999999
+BC644,Willow River,,British Columbia,CA,54.0787,-122.474
 BC645,Blind Channel,,British Columbia,CA,50.4167,-125.5
-BC646,Sparwood,,British Columbia,CA,49.7326,-114.89200000000001
+BC646,Sparwood,,British Columbia,CA,49.7326,-114.892
 BC647,Toosey,,British Columbia,CA,51.9323,-122.506
 BC648,Paterson,,British Columbia,CA,49.0067,-117.831
-BC649,Duncan,,British Columbia,CA,48.7789,-123.70200000000001
+BC649,Duncan,,British Columbia,CA,48.7789,-123.702
 BC650,Hixon,,British Columbia,CA,53.4204,-122.586
 BC651,Wardner,,British Columbia,CA,49.417,-115.429
 BC652,Pinantan Lake,,British Columbia,CA,50.7264,-120.036
-BC653,Garden Bay,,British Columbia,CA,49.6366,-124.03399999999999
+BC653,Garden Bay,,British Columbia,CA,49.6366,-124.034
 BC654,Musgrave Landing,,British Columbia,CA,48.7511,-123.546
-BC655,Rumble Beach,,British Columbia,CA,50.4265,-127.48200000000001
+BC655,Rumble Beach,,British Columbia,CA,50.4265,-127.482
 BC656,Elko,,British Columbia,CA,49.3012,-115.111
 BC657,Canyon Hot Springs,,British Columbia,CA,51.1369,-117.852
 BC658,Deep Cove,,British Columbia,CA,49.3232,-122.948
 BC659,North Bend,,British Columbia,CA,49.8833,-121.45
 BC660,Armstrong,,British Columbia,CA,50.4461,-119.199
-BC661,Esquimalt,,British Columbia,CA,48.4289,-123.40799999999999
-BC662,Endako,,British Columbia,CA,54.0875,-125.01700000000001
-BC663,Radium Hot Springs,,British Columbia,CA,50.623000000000005,-116.08
+BC661,Esquimalt,,British Columbia,CA,48.4289,-123.408
+BC662,Endako,,British Columbia,CA,54.0875,-125.017
+BC663,Radium Hot Springs,,British Columbia,CA,50.623,-116.08
 BC664,100 Mile House,,British Columbia,CA,51.6391,-121.294
 BC665,Mapes,,British Columbia,CA,53.8833,-123.867
-BC666,Pleasantside,,British Columbia,CA,49.2934,-122.84700000000001
+BC666,Pleasantside,,British Columbia,CA,49.2934,-122.847
 BC667,Procter,,British Columbia,CA,49.6156,-116.956
 BC668,Seaford,,British Columbia,CA,50.0833,-124.9
 BC669,Malakwa,,British Columbia,CA,50.94,-118.789
-BC670,Alexis Creek,,British Columbia,CA,52.0833,-123.28299999999999
+BC670,Alexis Creek,,British Columbia,CA,52.0833,-123.283
 BC671,Canyon,,British Columbia,CA,49.0813,-116.443
 BC672,Fort Steele,,British Columbia,CA,49.6169,-115.626
 BC673,Gwa'Sala- Nakwaxda'xw,,British Columbia,CA,50.7333,-127.5
-BC674,Saltery Bay,,British Columbia,CA,49.7833,-124.18299999999999
-BC675,Dunster,,British Columbia,CA,53.126999999999995,-119.839
-BC676,Bridesville,,British Columbia,CA,49.0358,-119.14200000000001
+BC674,Saltery Bay,,British Columbia,CA,49.7833,-124.183
+BC675,Dunster,,British Columbia,CA,53.127,-119.839
+BC676,Bridesville,,British Columbia,CA,49.0358,-119.142
 BC677,40 Mile Flats,,British Columbia,CA,57.9363,-130.05
 BC678,Hedley,,British Columbia,CA,49.3604,-120.072
 BC679,Ootischenia,,British Columbia,CA,49.2833,-117.633
 BC680,Hagwilget,,British Columbia,CA,55.2546,-127.596
 BC681,Gibsons,,British Columbia,CA,49.4018,-123.514
-BC682,Welcome Beach,,British Columbia,CA,49.48,-123.89399999999999
+BC682,Welcome Beach,,British Columbia,CA,49.48,-123.894
 BC683,Soowahlie,,British Columbia,CA,49.0814,-121.963
 BC684,Vavenby,,British Columbia,CA,51.5858,-119.726
 BC685,Bold Point,,British Columbia,CA,50.1732,-125.156
 BC686,Likely,,British Columbia,CA,52.6187,-121.565
 BC687,Dundarave,,British Columbia,CA,49.338,-123.181
 BC688,Kitkatla,,British Columbia,CA,53.7922,-130.433
-BC689,South Hazelton,,British Columbia,CA,55.2375,-127.65899999999999
+BC689,South Hazelton,,British Columbia,CA,55.2375,-127.659
 BC690,Fort Langley,,British Columbia,CA,49.1667,-122.583
 BC691,Dry Gulch,,British Columbia,CA,50.5842,-116.041
 BC692,Departure Bay,,British Columbia,CA,49.2054,-123.975
@@ -696,46 +696,46 @@ BC694,Mesachie Lake,,British Columbia,CA,48.8124,-124.125
 BC695,Jaffray,,British Columbia,CA,49.3744,-115.3
 BC696,Kitsault,,British Columbia,CA,55.4558,-129.471
 BC697,Golden,,British Columbia,CA,51.2949,-116.964
-BC698,Vanderhoof,,British Columbia,CA,54.0175,-124.00200000000001
+BC698,Vanderhoof,,British Columbia,CA,54.0175,-124.002
 BC699,Red Bluff,,British Columbia,CA,52.9654,-122.461
-BC700,Port Edward,,British Columbia,CA,54.2224,-130.28799999999998
+BC700,Port Edward,,British Columbia,CA,54.2224,-130.288
 BC701,Ocean Falls,,British Columbia,CA,52.3472,-127.689
-BC702,Promontory,,British Columbia,CA,49.1006,-121.93700000000001
+BC702,Promontory,,British Columbia,CA,49.1006,-121.937
 BC703,Yarrow,,British Columbia,CA,49.0833,-122.05
 BC704,Sardis,,British Columbia,CA,49.1367,-121.959
 BC705,Lardeau,,British Columbia,CA,50.143,-116.956
-BC706,Vernon,,British Columbia,CA,50.2642,-119.26899999999999
-BC707,Campbell Creek,,British Columbia,CA,50.653999999999996,-120.085
-BC708,Beaton,,British Columbia,CA,50.7333,-117.73299999999999
-BC709,Logan Lake,,British Columbia,CA,50.4913,-120.81299999999999
+BC706,Vernon,,British Columbia,CA,50.2642,-119.269
+BC707,Campbell Creek,,British Columbia,CA,50.654,-120.085
+BC708,Beaton,,British Columbia,CA,50.7333,-117.733
+BC709,Logan Lake,,British Columbia,CA,50.4913,-120.813
 BC710,Okanagan Falls,,British Columbia,CA,49.3428,-119.571
 BC711,Moricetown,,British Columbia,CA,55.0183,-127.331
 BC712,Revelstoke,,British Columbia,CA,51.0012,-118.196
 BC713,Siska,,British Columbia,CA,50.1386,-121.571
 BC714,Kitimat,,British Columbia,CA,54.051,-128.651
-BC715,Haig,,British Columbia,CA,49.3967,-121.45299999999999
+BC715,Haig,,British Columbia,CA,49.3967,-121.453
 BC716,Whistler Creek,,British Columbia,CA,50.0935,-122.993
 BC717,Pavilion,,British Columbia,CA,50.8833,-121.833
 BC718,Warfield,,British Columbia,CA,49.0945,-117.749
-BC719,Fruitvale,,British Columbia,CA,49.1139,-117.54799999999999
-BC720,Mara,,British Columbia,CA,50.6853,-119.06700000000001
+BC719,Fruitvale,,British Columbia,CA,49.1139,-117.548
+BC720,Mara,,British Columbia,CA,50.6853,-119.067
 BC721,Taghum,,British Columbia,CA,49.4934,-117.399
 BC722,Lawnhill,,British Columbia,CA,53.4036,-131.922
 BC723,Gold River,,British Columbia,CA,49.7807,-126.052
 BC724,Lax̱g̱altsʼap,,British Columbia,CA,55.0306,-129.575
-BC725,Ardmore,,British Columbia,CA,48.6389,-123.46700000000001
-BC726,Kakawis,,British Columbia,CA,49.18899999999999,-125.911
+BC725,Ardmore,,British Columbia,CA,48.6389,-123.467
+BC726,Kakawis,,British Columbia,CA,49.189,-125.911
 BC727,Hazelton,,British Columbia,CA,55.2546,-127.676
 BC728,Cawston,,British Columbia,CA,49.1802,-119.764
-BC729,Chase,,British Columbia,CA,50.8221,-119.68799999999999
-BC730,Bear Flat,,British Columbia,CA,56.273999999999994,-121.23100000000001
+BC729,Chase,,British Columbia,CA,50.8221,-119.688
+BC730,Bear Flat,,British Columbia,CA,56.274,-121.231
 BC731,Echo Bay,,British Columbia,CA,50.7485,-126.494
 BC732,Ladysmith,,British Columbia,CA,48.9926,-123.82
 BC733,Kitsumkalum,,British Columbia,CA,54.5245,-128.672
 BC734,Kitchener,,British Columbia,CA,49.1567,-116.339
 BC735,Parson,,British Columbia,CA,51.0708,-116.632
-BC736,Sunshine Valley,,British Columbia,CA,49.2727,-121.23899999999999
-BC737,Skidegate Landing,,British Columbia,CA,53.2472,-132.00799999999998
+BC736,Sunshine Valley,,British Columbia,CA,49.2727,-121.239
+BC737,Skidegate Landing,,British Columbia,CA,53.2472,-132.008
 BC738,Southbank,,British Columbia,CA,54.0212,-125.771
 BC739,Burns Lake,,British Columbia,CA,54.2314,-125.76
 BC740,Dunsmuir,,British Columbia,CA,49.3881,-124.609
@@ -743,59 +743,59 @@ BC741,Delbrook,,British Columbia,CA,49.343,-123.085
 BC742,Dallas,,British Columbia,CA,50.6667,-120.167
 BC743,Lake Cowichan,,British Columbia,CA,48.8261,-124.052
 BC744,Houston,,British Columbia,CA,54.397,-126.652
-BC745,Savona,,British Columbia,CA,50.7511,-120.84100000000001
-BC746,Bella Coola,,British Columbia,CA,52.3706,-126.75200000000001
+BC745,Savona,,British Columbia,CA,50.7511,-120.841
+BC746,Bella Coola,,British Columbia,CA,52.3706,-126.752
 BC747,Bowser,,British Columbia,CA,49.4387,-124.685
 BC748,Kispiox,,British Columbia,CA,55.3503,-127.691
 BC749,Esperanza,,British Columbia,CA,49.8713,-126.738
 BC750,Shady Valley,,British Columbia,CA,53.9793,-122.727
 BC751,Blackpool,,British Columbia,CA,51.5969,-120.12
 BC752,Westbank,,British Columbia,CA,49.8286,-119.631
-BC753,Wilmer,,British Columbia,CA,50.5426,-116.06299999999999
+BC753,Wilmer,,British Columbia,CA,50.5426,-116.063
 BC754,Laidlaw,,British Columbia,CA,49.3223,-121.618
 BC755,Tseycum,,British Columbia,CA,48.6645,-123.448
 BC756,Youbou,,British Columbia,CA,48.8726,-124.199
-BC757,Pendleton Bay,,British Columbia,CA,54.5167,-125.71700000000001
-BC758,Ashton Creek,,British Columbia,CA,50.556000000000004,-119.01299999999999
-BC759,Fraser Lake,,British Columbia,CA,54.0583,-124.84700000000001
+BC757,Pendleton Bay,,British Columbia,CA,54.5167,-125.717
+BC758,Ashton Creek,,British Columbia,CA,50.556,-119.013
+BC759,Fraser Lake,,British Columbia,CA,54.0583,-124.847
 BC760,Danskin,,British Columbia,CA,53.9889,-125.792
-BC761,Willow Valley,,British Columbia,CA,55.8563,-120.87200000000001
+BC761,Willow Valley,,British Columbia,CA,55.8563,-120.872
 BC762,Meadow Creek,,British Columbia,CA,50.2392,-116.973
-BC763,Seymour Heights,,British Columbia,CA,49.3192,-123.00200000000001
+BC763,Seymour Heights,,British Columbia,CA,49.3192,-123.002
 BC764,Sikanni Chief,,British Columbia,CA,57.2346,-122.695
 BC765,Caesars,,British Columbia,CA,50.0667,-119.5
-BC766,Crofton,,British Columbia,CA,48.8632,-123.64299999999999
+BC766,Crofton,,British Columbia,CA,48.8632,-123.643
 BC767,Good Hope Lake,,British Columbia,CA,59.2936,-129.289
 BC768,Whyac,,British Columbia,CA,48.6691,-124.846
 BC769,Refuge Cove,,British Columbia,CA,50.1238,-124.836
 BC770,Marysville,,British Columbia,CA,49.6373,-115.956
 BC771,Tofino,,British Columbia,CA,49.1505,-125.906
 BC772,Maple Ridge,,British Columbia,CA,49.2174,-122.598
-BC773,Traders Cove,,British Columbia,CA,49.9361,-119.50399999999999
+BC773,Traders Cove,,British Columbia,CA,49.9361,-119.504
 BC774,Tsay Keh Dene,,British Columbia,CA,56.8918,-124.963
 BC775,Clinton,,British Columbia,CA,51.0942,-121.587
 BC776,Port Clements,,British Columbia,CA,53.6852,-132.179
 BC777,Osoyoos,,British Columbia,CA,49.0311,-119.465
 BC778,Bliss Landing,,British Columbia,CA,50.0366,-124.816
-BC779,Kyuquot,,British Columbia,CA,50.0281,-127.37700000000001
+BC779,Kyuquot,,British Columbia,CA,50.0281,-127.377
 BC780,Beaverdell,,British Columbia,CA,49.4368,-119.089
 BC781,New Denver,,British Columbia,CA,49.9917,-117.374
 BC782,150 Mile House,,British Columbia,CA,52.1147,-121.935
 BC783,Sicamous,,British Columbia,CA,50.835,-118.98
-BC784,Telegraph Cove,,British Columbia,CA,50.5457,-126.82799999999999
+BC784,Telegraph Cove,,British Columbia,CA,50.5457,-126.828
 BC785,Towdystan,,British Columbia,CA,52.2634,-125.087
 BC786,Cinema,,British Columbia,CA,53.2333,-122.45
-BC787,Nakusp,,British Columbia,CA,50.2418,-117.79899999999999
+BC787,Nakusp,,British Columbia,CA,50.2418,-117.799
 BC788,Kingcome Inlet,,British Columbia,CA,50.95,-126.2
 BC789,Sooke,,British Columbia,CA,48.3823,-123.728
 BC790,Courtenay,,British Columbia,CA,49.6889,-124.999
 BC791,Boston Flats,,British Columbia,CA,50.7699,-121.304
 BC792,Jade City,,British Columbia,CA,59.2469,-129.655
-BC793,Spillimacheen,,British Columbia,CA,50.9072,-116.36399999999999
-BC794,Ashcroft,,British Columbia,CA,50.721000000000004,-121.28
+BC793,Spillimacheen,,British Columbia,CA,50.9072,-116.364
+BC794,Ashcroft,,British Columbia,CA,50.721,-121.28
 BC795,Hollyburn,,British Columbia,CA,49.3324,-123.163
-BC796,Honeymoon Bay,,British Columbia,CA,48.815,-124.17299999999999
-BC797,Ocean Grove,,British Columbia,CA,49.9524,-125.20200000000001
+BC796,Honeymoon Bay,,British Columbia,CA,48.815,-124.173
+BC797,Ocean Grove,,British Columbia,CA,49.9524,-125.202
 BC798,Tranquille,,British Columbia,CA,50.72,-120.521
 BC799,Huntingdon,,British Columbia,CA,49.0051,-122.266
 BC800,Brookmere,,British Columbia,CA,49.8181,-120.875
@@ -804,25 +804,25 @@ BC802,Dogwood Valley,,British Columbia,CA,49.4845,-121.425
 BC803,Anzac,,British Columbia,CA,54.7667,-122.5
 BC804,Salmo,,British Columbia,CA,49.1916,-117.277
 BC805,Walhachin,,British Columbia,CA,50.7515,-120.991
-BC806,Kimberley,,British Columbia,CA,49.6871,-115.98299999999999
+BC806,Kimberley,,British Columbia,CA,49.6871,-115.983
 BC807,Oyama,,British Columbia,CA,50.1111,-119.368
 BC808,Nanaimo,,British Columbia,CA,49.1659,-123.939
 BC809,Oliver,,British Columbia,CA,49.1826,-119.553
 BC810,Caulfeild,,British Columbia,CA,49.3416,-123.26
 BC811,Wycliffe,,British Columbia,CA,49.6013,-115.861
 BC812,White Rock,,British Columbia,CA,49.0252,-122.796
-BC813,Sorrento,,British Columbia,CA,50.8782,-119.46700000000001
-BC814,Alpine Meadows,,British Columbia,CA,50.15,-122.96700000000001
-BC815,Eastgate,,British Columbia,CA,49.1375,-120.61200000000001
+BC813,Sorrento,,British Columbia,CA,50.8782,-119.467
+BC814,Alpine Meadows,,British Columbia,CA,50.15,-122.967
+BC815,Eastgate,,British Columbia,CA,49.1375,-120.612
 BC816,Britannia Beach,,British Columbia,CA,49.628,-123.204
-BC817,Celista,,British Columbia,CA,50.9444,-119.34899999999999
-BC818,Ta Ta Creek,,British Columbia,CA,49.7833,-115.78299999999999
+BC817,Celista,,British Columbia,CA,50.9444,-119.349
+BC818,Ta Ta Creek,,British Columbia,CA,49.7833,-115.783
 BC819,Redstone,,British Columbia,CA,52.1333,-123.7
 BC820,Spuzzum,,British Columbia,CA,49.6886,-121.417
-BC821,Stellako,,British Columbia,CA,54.0622,-124.90299999999999
+BC821,Stellako,,British Columbia,CA,54.0622,-124.903
 BC822,Glenemma,,British Columbia,CA,50.4694,-119.352
-BC823,Lavington,,British Columbia,CA,50.2313,-119.10700000000001
-BC824,Mayne,,British Columbia,CA,48.8501,-123.29700000000001
+BC823,Lavington,,British Columbia,CA,50.2313,-119.107
+BC824,Mayne,,British Columbia,CA,48.8501,-123.297
 BC825,Kaleden,,British Columbia,CA,49.3928,-119.596
 BC826,Trout Lake,,British Columbia,CA,50.6472,-117.539
 BC827,Gitwinksihlkw,,British Columbia,CA,55.1937,-129.219
@@ -830,20 +830,20 @@ BC828,Crawford Bay,,British Columbia,CA,49.6766,-116.822
 BC829,Coalmont,,British Columbia,CA,49.5089,-120.695
 BC830,Semiahmoo,,British Columbia,CA,49.0126,-122.766
 BC831,Soda Creek,,British Columbia,CA,52.3275,-122.275
-BC832,Rolla,,British Columbia,CA,55.8986,-120.14299999999999
+BC832,Rolla,,British Columbia,CA,55.8986,-120.143
 BC833,Kingsgate,,British Columbia,CA,49.0024,-116.178
-BC834,Ellison,,British Columbia,CA,49.9363,-119.35799999999999
+BC834,Ellison,,British Columbia,CA,49.9363,-119.358
 BC835,Dorreen,,British Columbia,CA,54.8389,-128.346
 BC836,Westbridge,,British Columbia,CA,49.1715,-118.975
-BC837,Prespatou,,British Columbia,CA,56.9223,-121.06299999999999
-BC838,Cokato,,British Columbia,CA,49.4667,-115.06700000000001
-BC839,Lasqueti,,British Columbia,CA,49.4918,-124.34700000000001
+BC837,Prespatou,,British Columbia,CA,56.9223,-121.063
+BC838,Cokato,,British Columbia,CA,49.4667,-115.067
+BC839,Lasqueti,,British Columbia,CA,49.4918,-124.347
 BC840,Langdale,,British Columbia,CA,49.4341,-123.477
 BC841,Glen Vowell,,British Columbia,CA,55.3135,-127.677
-BC842,Christina Lake,,British Columbia,CA,49.0392,-118.21600000000001
+BC842,Christina Lake,,British Columbia,CA,49.0392,-118.216
 BC843,Fort Nelson,,British Columbia,CA,58.8056,-122.697
-BC844,Rosedale,,British Columbia,CA,49.181999999999995,-121.804
-BC845,Magna Bay,,British Columbia,CA,50.9618,-119.28399999999999
+BC844,Rosedale,,British Columbia,CA,49.182,-121.804
+BC845,Magna Bay,,British Columbia,CA,50.9618,-119.284
 BC846,Howser,,British Columbia,CA,50.3,-116.95
 BC847,Ainsworth Hot Springs,,British Columbia,CA,49.7343,-116.913
 BC848,Germansen Landing,,British Columbia,CA,55.7833,-124.7
@@ -851,13 +851,13 @@ BC849,Rutland,,British Columbia,CA,49.8883,-119.391
 BC850,Tappen,,British Columbia,CA,50.784,-119.331
 BC851,Sewall,,British Columbia,CA,53.7625,-132.298
 BC852,Hosmer,,British Columbia,CA,49.5897,-114.964
-BC853,Grindrod,,British Columbia,CA,50.6276,-119.12299999999999
+BC853,Grindrod,,British Columbia,CA,50.6276,-119.123
 BC854,Bonnet Hill,,British Columbia,CA,53.9,-122.617
 BC855,Dease Lake,,British Columbia,CA,58.4394,-129.996
 BC856,Rayleigh,,British Columbia,CA,50.7974,-120.32
 BC857,New Hazelton,,British Columbia,CA,55.2466,-127.586
 BC858,Rock Creek,,British Columbia,CA,49.0596,-118.999
-BC859,Annis,,British Columbia,CA,50.7907,-119.08200000000001
+BC859,Annis,,British Columbia,CA,50.7907,-119.082
 BC860,Rose Harbour,,British Columbia,CA,52.1477,-131.085
 BC861,Bella Bella,,British Columbia,CA,52.1639,-128.144
 BC862,Buckhorn,,British Columbia,CA,53.7942,-122.655
@@ -865,53 +865,53 @@ BC863,Heffley Creek,,British Columbia,CA,50.8583,-120.271
 BC864,Shearwater,,British Columbia,CA,52.1466,-128.092
 BC865,Forest Grove,,British Columbia,CA,51.7667,-121.1
 BC866,Cache Creek,,British Columbia,CA,50.8119,-121.323
-BC867,Wildwood,,British Columbia,CA,49.891000000000005,-124.557
-BC868,Keremeos,,British Columbia,CA,49.2064,-119.82600000000001
+BC867,Wildwood,,British Columbia,CA,49.891,-124.557
+BC868,Keremeos,,British Columbia,CA,49.2064,-119.826
 BC869,Albreda,,British Columbia,CA,52.6375,-119.162
 BC870,Yale,,British Columbia,CA,49.5632,-121.43
 BC871,Durieu,,British Columbia,CA,49.2175,-122.235
 BC872,Lund,,British Columbia,CA,49.9818,-124.757
 BC873,Avola,,British Columbia,CA,51.7812,-119.323
-BC874,Kitamaat Village,,British Columbia,CA,53.9737,-128.64700000000002
+BC874,Kitamaat Village,,British Columbia,CA,53.9737,-128.647
 BC875,Stoner,,British Columbia,CA,53.6291,-122.662
 BC876,Tachie,,British Columbia,CA,54.6548,-124.758
-BC877,Qualicum Beach,,British Columbia,CA,49.3475,-124.44200000000001
-BC878,Lynn Valley,,British Columbia,CA,49.3416,-123.03299999999999
+BC877,Qualicum Beach,,British Columbia,CA,49.3475,-124.442
+BC878,Lynn Valley,,British Columbia,CA,49.3416,-123.033
 BC879,Chehalis,,British Columbia,CA,49.2918,-121.911
-BC880,Harrison Hot Springs,,British Columbia,CA,49.3,-121.78299999999999
+BC880,Harrison Hot Springs,,British Columbia,CA,49.3,-121.783
 BC881,Dodge Cove,,British Columbia,CA,54.2878,-130.387
 BC882,Dawson Creek,,British Columbia,CA,55.7595,-120.235
-BC883,Krestova,,British Columbia,CA,49.4447,-117.58200000000001
+BC883,Krestova,,British Columbia,CA,49.4447,-117.582
 BC884,Silver River,,British Columbia,CA,49.5756,-121.818
 BC885,French Creek,,British Columbia,CA,49.3471,-124.36
-BC886,Montrose,,British Columbia,CA,49.0788,-117.59100000000001
-BC887,Slocan,,British Columbia,CA,49.7667,-117.46700000000001
+BC886,Montrose,,British Columbia,CA,49.0788,-117.591
+BC887,Slocan,,British Columbia,CA,49.7667,-117.467
 BC888,Sidney,,British Columbia,CA,48.65,-123.4
-BC889,Raspberry,,British Columbia,CA,49.3358,-117.65700000000001
+BC889,Raspberry,,British Columbia,CA,49.3358,-117.657
 BC890,Rossland,,British Columbia,CA,49.0775,-117.801
 BC891,McCulloch,,British Columbia,CA,49.7948,-119.19
-BC892,Bell II,,British Columbia,CA,56.7444,-129.79399999999998
+BC892,Bell II,,British Columbia,CA,56.7444,-129.794
 BC893,Glade,,British Columbia,CA,49.3964,-117.535
 BC894,Wonowon,,British Columbia,CA,56.7288,-121.814
 BC895,Comox,,British Columbia,CA,49.6739,-124.928
 BC896,Burton,,British Columbia,CA,49.9856,-117.88
 BC897,Maple Bay,,British Columbia,CA,48.8158,-123.613
 BC898,Tsawout,,British Columbia,CA,48.588,-123.387
-BC899,Coombs,,British Columbia,CA,49.3044,-124.41799999999999
+BC899,Coombs,,British Columbia,CA,49.3044,-124.418
 BC900,South Shalalth,,British Columbia,CA,50.7288,-122.244
-BC901,Lazo,,British Columbia,CA,49.7139,-124.90899999999999
-BC902,Bonnington Falls,,British Columbia,CA,49.4667,-117.48299999999999
+BC901,Lazo,,British Columbia,CA,49.7139,-124.909
+BC902,Bonnington Falls,,British Columbia,CA,49.4667,-117.483
 BC903,Bell Acres,,British Columbia,CA,49.078,-121.866
-BC904,Zamora,,British Columbia,CA,49.15,-118.98299999999999
-BC905,Brilliant,,British Columbia,CA,49.3217,-117.64299999999999
-BC906,Cascade,,British Columbia,CA,49.0187,-118.20700000000001
-BC907,Donnely Landing,,British Columbia,CA,49.625,-124.04299999999999
+BC904,Zamora,,British Columbia,CA,49.15,-118.983
+BC905,Brilliant,,British Columbia,CA,49.3217,-117.643
+BC906,Cascade,,British Columbia,CA,49.0187,-118.207
+BC907,Donnely Landing,,British Columbia,CA,49.625,-124.043
 BC908,Steamboat,,British Columbia,CA,58.6756,-123.712
 BC909,Merritt,,British Columbia,CA,50.1114,-120.79
 BC910,Gingolx,,British Columbia,CA,54.9944,-129.954
 BC911,Canoe,,British Columbia,CA,50.7515,-119.227
-BC912,Groundbirch,,British Columbia,CA,55.78,-120.92299999999999
-BC913,Moyie,,British Columbia,CA,49.2888,-115.83200000000001
+BC912,Groundbirch,,British Columbia,CA,55.78,-120.923
+BC913,Moyie,,British Columbia,CA,49.2888,-115.832
 BC914,Lytton,,British Columbia,CA,50.2316,-121.583
 BC915,Royston,,British Columbia,CA,49.6454,-124.945
 BC916,Westsyde,,British Columbia,CA,50.7637,-120.348
@@ -920,7 +920,7 @@ BC918,Tulameen,,British Columbia,CA,49.5458,-120.758
 BC919,Deep Bay,,British Columbia,CA,49.4642,-124.725
 BC920,Barnhartvale,,British Columbia,CA,50.6505,-120.17
 BC921,Fulford Harbour,,British Columbia,CA,48.7706,-123.45
-BC922,Ymir,,British Columbia,CA,49.2833,-117.21700000000001
+BC922,Ymir,,British Columbia,CA,49.2833,-117.217
 BC923,Rosebery,,British Columbia,CA,50.0333,-117.411
 BC924,Altona,,British Columbia,CA,56.8775,-120.954
 BC925,Meziadin Junction,,British Columbia,CA,56.0997,-129.305
@@ -928,7 +928,7 @@ BC926,Nahun,,British Columbia,CA,50.0833,-119.5
 BC927,Edgewater,,British Columbia,CA,50.7,-116.133
 BC928,Shirley,,British Columbia,CA,48.3898,-123.904
 BC929,Sunnybrae,,British Columbia,CA,50.7732,-119.27
-BC930,Lumby,,British Columbia,CA,50.25,-118.96700000000001
+BC930,Lumby,,British Columbia,CA,50.25,-118.967
 BC931,Merville,,British Columbia,CA,49.7848,-125.057
 BC932,Wells,,British Columbia,CA,53.1041,-121.571
 BC933,Telkwa,,British Columbia,CA,54.6972,-127.05
@@ -938,29 +938,29 @@ BC936,Thornhill,,British Columbia,CA,54.5125,-128.54
 BC937,Hatzic Island,,British Columbia,CA,49.1624,-122.236
 BC938,Rich Bar,,British Columbia,CA,52.9149,-122.456
 BC939,Yaculta,,British Columbia,CA,50.0217,-125.195
-BC940,Old Town,,British Columbia,CA,49.55,-115.96700000000001
+BC940,Old Town,,British Columbia,CA,49.55,-115.967
 BC941,Shoreacres,,British Columbia,CA,49.4307,-117.527
 BC942,Bear Lake,,British Columbia,CA,54.4959,-122.679
 BC943,Clayhurst,,British Columbia,CA,56.1868,-120.03
 BC944,Fraser,,British Columbia,CA,59.7159,-135.049
-BC945,Hydraulic,,British Columbia,CA,52.6148,-121.70700000000001
+BC945,Hydraulic,,British Columbia,CA,52.6148,-121.707
 BC946,Union Bay,,British Columbia,CA,49.5802,-124.885
 BC947,Weneez,,British Columbia,CA,53.9677,-123.98
-BC948,Riondel,,British Columbia,CA,49.7618,-116.85600000000001
+BC948,Riondel,,British Columbia,CA,49.7618,-116.856
 BC949,Marshall School Junction,,British Columbia,CA,49.7111,-124.509
-BC950,Shawnigan Lake,,British Columbia,CA,48.6535,-123.62200000000001
+BC950,Shawnigan Lake,,British Columbia,CA,48.6535,-123.622
 BC951,Kilkerran,,British Columbia,CA,55.8395,-120.272
 BC952,Seven Mile Corner,,British Columbia,CA,55.8976,-120.324
 BC953,Red Rock,,British Columbia,CA,53.6886,-122.671
 BC954,Errington,,British Columbia,CA,49.2889,-124.37
-BC955,Egmont,,British Columbia,CA,49.75,-123.93299999999999
-BC956,Kinnaird,,British Columbia,CA,49.2834,-117.65100000000001
+BC955,Egmont,,British Columbia,CA,49.75,-123.933
+BC956,Kinnaird,,British Columbia,CA,49.2834,-117.651
 BC957,Olalla,,British Columbia,CA,49.2634,-119.829
-BC958,Little Fort,,British Columbia,CA,51.4249,-120.20700000000001
+BC958,Little Fort,,British Columbia,CA,51.4249,-120.207
 BC959,Lions Bay,,British Columbia,CA,49.4591,-123.236
 BC960,Cassidy,,British Columbia,CA,49.05,-123.883
 BC961,Kitwanga,,British Columbia,CA,55.1,-128.067
-BC962,Silverton,,British Columbia,CA,49.9528,-117.35799999999999
+BC962,Silverton,,British Columbia,CA,49.9528,-117.358
 BC963,Pleasant Camp,,British Columbia,CA,59.4546,-136.365
 BC964,Westholme,,British Columbia,CA,48.8667,-123.7
 BC965,Montney,,British Columbia,CA,56.4503,-120.926
@@ -971,18 +971,18 @@ BC969,Spences Bridge,,British Columbia,CA,50.4234,-121.344
 BC970,Bessborough,,British Columbia,CA,55.8109,-120.506
 BC971,Hemlock Valley,,British Columbia,CA,49.3769,-121.935
 BC972,Falkland,,British Columbia,CA,50.5009,-119.557
-BC973,Agassiz,,British Columbia,CA,49.2333,-121.76700000000001
+BC973,Agassiz,,British Columbia,CA,49.2333,-121.767
 BC974,Clearbrook,,British Columbia,CA,49.05,-122.333
 BC975,Winter Harbour,,British Columbia,CA,50.5167,-128.033
-BC976,Sointula,,British Columbia,CA,50.6333,-127.01700000000001
+BC976,Sointula,,British Columbia,CA,50.6333,-127.017
 BC977,Horsefly,,British Columbia,CA,52.3333,-121.417
-BC978,Noralee,,British Columbia,CA,53.9833,-126.43299999999999
+BC978,Noralee,,British Columbia,CA,53.9833,-126.433
 BC979,Esler,,British Columbia,CA,52.1042,-122.184
-BC980,Goodlow,,British Columbia,CA,56.3336,-120.13600000000001
+BC980,Goodlow,,British Columbia,CA,56.3336,-120.136
 BC981,Brackendale,,British Columbia,CA,49.7667,-123.15
-BC982,103 Mile,,British Columbia,CA,51.68899999999999,-121.314
+BC982,103 Mile,,British Columbia,CA,51.689,-121.314
 BC983,105 Mile House,,British Columbia,CA,51.7069,-121.331
-BC984,122 Mile House,,British Columbia,CA,51.8483,-121.59899999999999
+BC984,122 Mile House,,British Columbia,CA,51.8483,-121.599
 BC985,141 Mile House,,British Columbia,CA,51.994,-121.846
 BC986,Ahousat,,British Columbia,CA,49.2842,-126.074
 BC987,Akisqnuk,,British Columbia,CA,50.4512,-115.96
@@ -1000,36 +1000,36 @@ BC998,Clemretta,,British Columbia,CA,54.0038,-126.285
 BC999,Cook's Ferry,,British Columbia,CA,50.4223,-121.32
 BC1000,Deerholme,,British Columbia,CA,48.7528,-123.758
 BC1001,Dokie Siding,,British Columbia,CA,55.6625,-121.734
-BC1002,Duncanby Landing,,British Columbia,CA,51.4065,-127.64399999999999
-BC1003,East Wellington,,British Columbia,CA,49.1838,-124.01799999999999
+BC1002,Duncanby Landing,,British Columbia,CA,51.4065,-127.644
+BC1003,East Wellington,,British Columbia,CA,49.1838,-124.018
 BC1004,François Lake,,British Columbia,CA,54.0517,-125.7419
 BC1005,Georgetown Mills,,British Columbia,CA,54.4716,-130.398
 BC1006,Gitanyow,,British Columbia,CA,55.2676,-128.072
 BC1007,Grand Haven,,British Columbia,CA,56.2402,-120.899
 BC1008,Harrogate,,British Columbia,CA,50.9833,-116.45
-BC1009,Imperial Ranchettes,,British Columbia,CA,51.613,-121.18299999999999
+BC1009,Imperial Ranchettes,,British Columbia,CA,51.613,-121.183
 BC1010,Johnsons Landing,,British Columbia,CA,50.0833,-116.883
-BC1011,Kendrick Camp,,British Columbia,CA,49.7244,-126.65100000000001
+BC1011,Kendrick Camp,,British Columbia,CA,49.7244,-126.651
 BC1012,Killiney Beach,,British Columbia,CA,50.1899,-119.506
-BC1013,Martin Prairie,,British Columbia,CA,50.6624,-119.81200000000001
+BC1013,Martin Prairie,,British Columbia,CA,50.6624,-119.812
 BC1014,Matilpi,,British Columbia,CA,50.5494,-126.184
-BC1015,Mile 62 1/2,,British Columbia,CA,56.4084,-121.15700000000001
-BC1016,Mount Baldy,,British Columbia,CA,49.1522,-119.23700000000001
+BC1015,Mile 62 1/2,,British Columbia,CA,56.4084,-121.157
+BC1016,Mount Baldy,,British Columbia,CA,49.1522,-119.237
 BC1017,Nadleh Whuten,,British Columbia,CA,54.0885,-124.598
 BC1018,Nee-Tahi-Buhn,,British Columbia,CA,54.0074,-125.956
-BC1019,New Brighton,,British Columbia,CA,49.45,-123.43299999999999
+BC1019,New Brighton,,British Columbia,CA,49.45,-123.433
 BC1020,Nuchatlaht,,British Columbia,CA,49.9901,-126.94
 BC1021,Park Siding,,British Columbia,CA,49.1725,-117.493
 BC1022,Peejay,,British Columbia,CA,56.8833,-120.617
-BC1023,Queens Cove,,British Columbia,CA,49.8833,-126.98299999999999
+BC1023,Queens Cove,,British Columbia,CA,49.8833,-126.983
 BC1024,Samahquam,,British Columbia,CA,50.0513,-122.539
 BC1025,Saulteau,,British Columbia,CA,55.835,-121.656
-BC1026,Selma Park,,British Columbia,CA,49.4585,-123.73299999999999
+BC1026,Selma Park,,British Columbia,CA,49.4585,-123.733
 BC1027,Shoreholme,,British Columbia,CA,50.3,-117.85
 BC1028,Six Mile,,British Columbia,CA,49.5785,-117.225
 BC1029,Skin Tyee,,British Columbia,CA,53.9486,-125.652
 BC1030,South Bentinck,,British Columbia,CA,52.0444,-126.667
-BC1031,South Lakeside,,British Columbia,CA,52.1083,-122.09700000000001
+BC1031,South Lakeside,,British Columbia,CA,52.1083,-122.097
 BC1032,South Taylor,,British Columbia,CA,56.1068,-120.634
 BC1033,St. Joseph Mission,,British Columbia,CA,52.0667,-121.95
 BC1034,Sugarcane,,British Columbia,CA,52.1088,-121.995

--- a/vector_data/point/manitoba_point_locations.csv
+++ b/vector_data/point/manitoba_point_locations.csv
@@ -12,29 +12,29 @@ MB10,Arborg,,Manitoba,CA,50.9083,-97.2153
 MB11,Arden,,Manitoba,CA,50.2777,-99.2685
 MB12,Argyle,,Manitoba,CA,50.1811,-97.4544
 MB13,Arnaud,,Manitoba,CA,49.2503,-97.1039
-MB14,Arnes,,Manitoba,CA,50.8026,-96.99799999999999
-MB15,Arrow River,,Manitoba,CA,50.1439,-100.89299999999999
+MB14,Arnes,,Manitoba,CA,50.8026,-96.998
+MB15,Arrow River,,Manitoba,CA,50.1439,-100.893
 MB16,Ashern,,Manitoba,CA,51.1822,-98.3456
-MB17,Ashville,,Manitoba,CA,51.1771,-100.29700000000001
+MB17,Ashville,,Manitoba,CA,51.1771,-100.297
 MB18,Aspen Park,,Manitoba,CA,50.6381,-97.0297
 MB19,Assiniboia,,Manitoba,CA,49.8987,-97.2978
 MB20,Aubigny,,Manitoba,CA,49.4581,-97.2458
 MB21,Austin,,Manitoba,CA,49.9503,-98.9361
 MB22,Bacon Ridge,,Manitoba,CA,51.0058,-99.0069
-MB23,Baden,,Manitoba,CA,52.7803,-101.21600000000001
+MB23,Baden,,Manitoba,CA,52.7803,-101.216
 MB24,Bagot,,Manitoba,CA,49.9692,-98.63
-MB25,Bakers Narrows,,Manitoba,CA,54.6715,-101.65899999999999
-MB26,Baldur,,Manitoba,CA,49.3856,-99.24700000000001
+MB25,Bakers Narrows,,Manitoba,CA,54.6715,-101.659
+MB26,Baldur,,Manitoba,CA,49.3856,-99.247
 MB27,Balmoral,,Manitoba,CA,50.2564,-97.3186
 MB28,Barkfield,,Manitoba,CA,49.3329,-96.802
 MB29,Barren Lands,,Manitoba,CA,57.9065,-101.56
 MB30,Barrows,,Manitoba,CA,52.8294,-101.441
-MB31,Basswood,,Manitoba,CA,50.3014,-100.03399999999999
+MB31,Basswood,,Manitoba,CA,50.3014,-100.034
 MB32,Beausejour,,Manitoba,CA,50.0622,-96.5161
-MB33,Belleview,,Manitoba,CA,49.6047,-100.85700000000001
+MB33,Belleview,,Manitoba,CA,49.6047,-100.857
 MB34,Bellsite,,Manitoba,CA,52.5942,-101.06
 MB35,Belmont,,Manitoba,CA,49.4094,-99.4564
-MB36,Benito,,Manitoba,CA,51.9139,-101.54799999999999
+MB36,Benito,,Manitoba,CA,51.9139,-101.548
 MB37,Berens River,,Manitoba,CA,52.3534,-97.0198
 MB38,Beresford,,Manitoba,CA,49.7303,-100.197
 MB39,Bernard Bay,,Manitoba,CA,49.8912,-97.052
@@ -42,16 +42,16 @@ MB40,Bethany,,Manitoba,CA,50.3125,-99.75
 MB41,Betula Lake,,Manitoba,CA,50.0683,-95.5786
 MB42,Beulah,,Manitoba,CA,50.2606,-101.037
 MB43,Bield,,Manitoba,CA,51.2211,-101.154
-MB44,Big Island Lake,,Manitoba,CA,54.6978,-101.76100000000001
+MB44,Big Island Lake,,Manitoba,CA,54.6978,-101.761
 MB45,Big Whiteshell Lake,,Manitoba,CA,50.0853,-95.3733
-MB46,Binscarth,,Manitoba,CA,50.6267,-101.28299999999999
+MB46,Binscarth,,Manitoba,CA,50.6267,-101.283
 MB47,Birch River,,Manitoba,CA,52.3961,-101.104
 MB48,Bird,,Manitoba,CA,56.5036,-94.2106
 MB49,Bird River,,Manitoba,CA,50.4128,-95.6794
 MB50,Birds Hill,,Manitoba,CA,49.975,-97.0053
 MB51,Birdtail Sioux,,Manitoba,CA,50.2667,-101.15
 MB52,Birnie,,Manitoba,CA,50.4472,-99.44
-MB53,Birtle,,Manitoba,CA,50.4225,-101.04799999999999
+MB53,Birtle,,Manitoba,CA,50.4225,-101.048
 MB54,Bissett,,Manitoba,CA,51.0229,-95.6753
 MB55,Bloodvein,,Manitoba,CA,51.7933,-96.6975
 MB56,Blumenfeld,,Manitoba,CA,49.0503,-97.9589
@@ -59,14 +59,14 @@ MB57,Blumenort,,Manitoba,CA,49.6044,-96.6889
 MB58,Blumenort South,,Manitoba,CA,49.0036,-97.6556
 MB59,Boggy Creek,,Manitoba,CA,51.535,-101.354
 MB60,Boissevain,,Manitoba,CA,49.2306,-100.055
-MB61,Bowsman,,Manitoba,CA,52.2358,-101.20700000000001
+MB61,Bowsman,,Manitoba,CA,52.2358,-101.207
 MB62,Bradwardine,,Manitoba,CA,49.9956,-100.464
 MB63,Brandon,,Manitoba,CA,49.8443,-99.9521
 MB64,Breezy Point,,Manitoba,CA,50.2717,-96.8492
 MB65,Brereton Lake,,Manitoba,CA,49.9136,-95.5286
 MB66,Brightstone,,Manitoba,CA,50.2828,-96.1667
 MB67,Broad Valley,,Manitoba,CA,50.9856,-97.6511
-MB68,Brochet,,Manitoba,CA,57.8869,-101.66799999999999
+MB68,Brochet,,Manitoba,CA,57.8869,-101.668
 MB69,Brokenhead Reserve,,Manitoba,CA,50.3708,-96.6296
 MB70,Brookdale,,Manitoba,CA,50.0481,-99.5636
 MB71,Brunkild,,Manitoba,CA,49.5928,-97.5744
@@ -82,7 +82,7 @@ MB80,Cardinal,,Manitoba,CA,49.4947,-98.555
 MB81,Carlowrie,,Manitoba,CA,49.2519,-96.9619
 MB82,Carman,,Manitoba,CA,49.504,-98.0037
 MB83,Carrick,,Manitoba,CA,49.2431,-96.0506
-MB84,Carroll,,Manitoba,CA,49.6075,-100.03200000000001
+MB84,Carroll,,Manitoba,CA,49.6075,-100.032
 MB85,Cartwright,,Manitoba,CA,49.0956,-99.34
 MB86,Cayer,,Manitoba,CA,51.3031,-99.1386
 MB87,Channing,,Manitoba,CA,54.7517,-101.829
@@ -103,7 +103,7 @@ MB101,Cottonwoods,,Manitoba,CA,49.8497,-99.7
 MB102,Coulter,,Manitoba,CA,49.0908,-100.985
 MB103,Cowan,,Manitoba,CA,52.033,-100.652
 MB104,Cranberry Portage,,Manitoba,CA,54.5848,-101.367
-MB105,Crandall,,Manitoba,CA,50.15,-100.78399999999999
+MB105,Crandall,,Manitoba,CA,50.15,-100.784
 MB106,Crane River,,Manitoba,CA,51.5343,-99.2871
 MB107,Cromer,,Manitoba,CA,49.7314,-101.235
 MB108,Cross Lake,,Manitoba,CA,54.6169,-97.7869
@@ -117,18 +117,18 @@ MB115,Dallas,,Manitoba,CA,51.3922,-97.485
 MB116,Dand,,Manitoba,CA,49.34,-100.5
 MB117,Darlingford,,Manitoba,CA,49.2039,-98.3781
 MB118,Dauphin,,Manitoba,CA,51.1474,-100.0629
-MB119,Dauphin,,Manitoba,CA,51.1494,-100.04899999999999
+MB119,Dauphin,,Manitoba,CA,51.1494,-100.049
 MB120,Dauphin River,,Manitoba,CA,51.9571,-98.0698
 MB121,Dawson Bay,,Manitoba,CA,52.9767,-100.98
 MB122,Deleau,,Manitoba,CA,49.5811,-100.575
-MB123,Deloraine,,Manitoba,CA,49.1911,-100.49799999999999
+MB123,Deloraine,,Manitoba,CA,49.1911,-100.498
 MB124,Delta Beach,,Manitoba,CA,50.1867,-98.3203
 MB125,Denbeigh Point,,Manitoba,CA,52.8931,-99.7819
 MB126,Dog Creek,,Manitoba,CA,50.9083,-98.5972
 MB127,Domain,,Manitoba,CA,49.6142,-97.3214
 MB128,Dominion City,,Manitoba,CA,49.1419,-97.1556
 MB129,Douglas Station,,Manitoba,CA,49.893,-99.7121
-MB130,Dropmore,,Manitoba,CA,51.0169,-101.44200000000001
+MB130,Dropmore,,Manitoba,CA,51.0169,-101.442
 MB131,Duck Bay,,Manitoba,CA,52.1727,-100.155
 MB132,Dufresne,,Manitoba,CA,49.7269,-96.7233
 MB133,Dufrost,,Manitoba,CA,49.3583,-97.0517
@@ -140,14 +140,14 @@ MB138,East Braintree,,Manitoba,CA,49.6194,-95.6233
 MB139,East Selkirk,,Manitoba,CA,50.1375,-96.8331
 MB140,Easterville,,Manitoba,CA,53.0975,-99.8175
 MB141,Ebb and Flow,,Manitoba,CA,51.0239,-99.039
-MB142,Ebor,,Manitoba,CA,49.7411,-101.33200000000001
+MB142,Ebor,,Manitoba,CA,49.7411,-101.332
 MB143,Eddystone,,Manitoba,CA,51.0903,-99.1497
 MB144,Eden,,Manitoba,CA,50.3764,-99.4694
 MB145,Edrans,,Manitoba,CA,50.0525,-99.1375
 MB146,Edwin,,Manitoba,CA,49.8894,-98.515
-MB147,Elgin,,Manitoba,CA,49.4439,-100.26899999999999
+MB147,Elgin,,Manitoba,CA,49.4439,-100.269
 MB148,Elie,,Manitoba,CA,49.9017,-97.7583
-MB149,Elkhorn,,Manitoba,CA,49.9756,-101.23899999999999
+MB149,Elkhorn,,Manitoba,CA,49.9756,-101.239
 MB150,Elm Creek,,Manitoba,CA,49.6756,-97.9925
 MB151,Elma,,Manitoba,CA,49.875,-95.9081
 MB152,Elphinstone,,Manitoba,CA,50.5311,-100.322
@@ -155,24 +155,24 @@ MB153,Elva,,Manitoba,CA,49.2161,-101.115
 MB154,Emerson,,Manitoba,CA,49.0069,-97.2147
 MB155,Erickson,,Manitoba,CA,50.4981,-99.9114
 MB156,Eriksdale,,Manitoba,CA,50.8628,-98.1011
-MB157,Ethelbert,,Manitoba,CA,51.5292,-100.39299999999999
-MB158,Fairfax,,Manitoba,CA,49.435,-100.12799999999999
+MB157,Ethelbert,,Manitoba,CA,51.5292,-100.393
+MB158,Fairfax,,Manitoba,CA,49.435,-100.128
 MB159,Fairford Reserve,,Manitoba,CA,51.5958,-98.6919
 MB160,Falcon Beach,,Manitoba,CA,49.6864,-95.3261
 MB161,Fannystelle,,Manitoba,CA,49.7447,-97.7778
-MB162,Faulkner,,Manitoba,CA,51.42100000000001,-98.6623
+MB162,Faulkner,,Manitoba,CA,51.421,-98.6623
 MB163,Firdale,,Manitoba,CA,49.9822,-99.1097
 MB164,Fisher Bay,,Manitoba,CA,51.4778,-97.2975
 MB165,Fisher Branch,,Manitoba,CA,51.0831,-97.62
 MB166,Fisher River,,Manitoba,CA,51.4377,-97.3911
 MB167,Fisher River,,Manitoba,CA,51.4022,-97.5314
-MB168,Flin Flon,,Manitoba,CA,54.7704,-101.85799999999999
+MB168,Flin Flon,,Manitoba,CA,54.7704,-101.858
 MB169,Fork River,,Manitoba,CA,51.5117,-100.02
 MB170,Forrest,,Manitoba,CA,49.9664,-99.9367
 MB171,Fort Alexander,,Manitoba,CA,50.6148,-96.3094
 MB172,Fort Garry,,Manitoba,CA,49.8414,-97.15
 MB173,Fortier,,Manitoba,CA,49.935,-97.9161
-MB174,Foxwarren,,Manitoba,CA,50.5172,-101.15100000000001
+MB174,Foxwarren,,Manitoba,CA,50.5172,-101.151
 MB175,Franklin,,Manitoba,CA,50.2442,-99.6647
 MB176,Fraserwood,,Manitoba,CA,50.6406,-97.2162
 MB177,Friedensruh,,Manitoba,CA,49.1336,-97.8683
@@ -181,7 +181,7 @@ MB179,Garden Hill,,Manitoba,CA,53.8833,-94.6489
 MB180,Gardenton,,Manitoba,CA,49.0869,-96.695
 MB181,Garland,,Manitoba,CA,51.6533,-100.459
 MB182,Garson,,Manitoba,CA,50.0778,-96.7067
-MB183,Gilbert Plains,,Manitoba,CA,51.1477,-100.48700000000001
+MB183,Gilbert Plains,,Manitoba,CA,51.1477,-100.487
 MB184,Gillam,,Manitoba,CA,56.3538,-94.7307
 MB185,Gimli,,Manitoba,CA,50.6336,-96.99
 MB186,Ginew,,Manitoba,CA,49.1403,-97.2431
@@ -219,7 +219,7 @@ MB217,Hacienda,,Manitoba,CA,49.8606,-97.3636
 MB218,Hadashville,,Manitoba,CA,49.6767,-95.9075
 MB219,Hallboro,,Manitoba,CA,50.1464,-99.4483
 MB220,Hamiota,,Manitoba,CA,50.1806,-100.596
-MB221,Harding,,Manitoba,CA,49.9903,-100.53200000000001
+MB221,Harding,,Manitoba,CA,49.9903,-100.532
 MB222,Hargrave,,Manitoba,CA,49.9172,-101.072
 MB223,Harrowby,,Manitoba,CA,50.7536,-101.448
 MB224,Hartney,,Manitoba,CA,49.4808,-100.522
@@ -228,7 +228,7 @@ MB226,Haskett,,Manitoba,CA,49.0183,-97.9722
 MB227,Haywood,,Manitoba,CA,49.6667,-98.1964
 MB228,Hazelridge,,Manitoba,CA,49.9658,-96.7153
 MB229,Headingley,,Manitoba,CA,49.8753,-97.4083
-MB230,Hecla,,Manitoba,CA,51.141999999999996,-96.6574
+MB230,Hecla,,Manitoba,CA,51.142,-96.6574
 MB231,Helston,,Manitoba,CA,50.1303,-99.1089
 MB232,Herb Lake,,Manitoba,CA,54.7773,-99.77
 MB233,High Bluff,,Manitoba,CA,50.0189,-98.1481
@@ -256,10 +256,10 @@ MB254,Justice,,Manitoba,CA,49.9961,-99.7992
 MB255,Kaleida,,Manitoba,CA,49.1289,-98.4678
 MB256,Kane,,Manitoba,CA,49.3544,-97.7272
 MB257,Katrime,,Manitoba,CA,50.0817,-98.7894
-MB258,Keeseekoowenin,,Manitoba,CA,50.5444,-100.29899999999999
+MB258,Keeseekoowenin,,Manitoba,CA,50.5444,-100.299
 MB259,Kelwood,,Manitoba,CA,50.6247,-99.4617
 MB260,Kemnay,,Manitoba,CA,49.8417,-100.134
-MB261,Kenton,,Manitoba,CA,49.9875,-100.61399999999999
+MB261,Kenton,,Manitoba,CA,49.9875,-100.614
 MB262,Kenville,,Manitoba,CA,52.0003,-101.324
 MB263,Keyes,,Manitoba,CA,50.2419,-99.1219
 MB264,Killarney,,Manitoba,CA,49.1833,-99.6628
@@ -268,13 +268,13 @@ MB266,Kinusisipi,,Manitoba,CA,53.9455,-97.8596
 MB267,Kirkella,,Manitoba,CA,50.0239,-101.365
 MB268,Kirkness,,Manitoba,CA,50.0783,-96.8619
 MB269,Kleefeld,,Manitoba,CA,49.5014,-96.8747
-MB270,Kola,,Manitoba,CA,49.8433,-101.37100000000001
+MB270,Kola,,Manitoba,CA,49.8433,-101.371
 MB271,Komarno,,Manitoba,CA,50.5067,-97.2506
 MB272,La Broquerie,,Manitoba,CA,49.5207,-96.5055
 MB273,La Coulée,,Manitoba,CA,49.6574,-96.5784
 MB274,La Rivière,,Manitoba,CA,49.2368,-98.6799
 MB275,La Salle,,Manitoba,CA,49.6931,-97.2639
-MB276,Lac Brochet,,Manitoba,CA,58.6189,-101.48700000000001
+MB276,Lac Brochet,,Manitoba,CA,58.6189,-101.487
 MB277,Lac du Bonnet,,Manitoba,CA,50.2517,-96.0587
 MB278,Ladywood,,Manitoba,CA,50.1803,-96.4968
 MB279,Lake Forest,,Manitoba,CA,50.7394,-96.9894
@@ -286,12 +286,12 @@ MB284,Langruth,,Manitoba,CA,50.3844,-98.6778
 MB285,Lauder,,Manitoba,CA,49.3906,-100.677
 MB286,Laurier,,Manitoba,CA,50.8897,-99.5603
 MB287,Lavenham,,Manitoba,CA,49.7961,-98.7194
-MB288,Lavinia,,Manitoba,CA,50.2744,-100.66799999999999
+MB288,Lavinia,,Manitoba,CA,50.2744,-100.668
 MB289,Leaf Rapids,,Manitoba,CA,56.4594,-100.005
 MB290,Lee River,,Manitoba,CA,50.2906,-95.8629
 MB291,Lena,,Manitoba,CA,49.0711,-99.6617
-MB292,Lenore,,Manitoba,CA,49.9583,-100.75200000000001
-MB293,Lenswood,,Manitoba,CA,52.3206,-100.95200000000001
+MB292,Lenore,,Manitoba,CA,49.9583,-100.752
+MB293,Lenswood,,Manitoba,CA,52.3206,-100.952
 MB294,Lester Beach,,Manitoba,CA,50.5858,-96.5756
 MB295,Letellier,,Manitoba,CA,49.1358,-97.3031
 MB296,Libau,,Manitoba,CA,50.2689,-96.7192
@@ -307,7 +307,7 @@ MB305,Lowe Farm,,Manitoba,CA,49.3547,-97.5889
 MB306,Lundar,,Manitoba,CA,50.6955,-98.0358
 MB307,Lundar Beach,,Manitoba,CA,50.73,-98.2836
 MB308,Lyleton,,Manitoba,CA,49.0578,-101.178
-MB309,Lynn Lake,,Manitoba,CA,56.8517,-101.04700000000001
+MB309,Lynn Lake,,Manitoba,CA,56.8517,-101.047
 MB310,Macdonald,,Manitoba,CA,50.0575,-98.4664
 MB311,MacGregor,,Manitoba,CA,49.9661,-98.7786
 MB312,Mafeking,,Manitoba,CA,52.6836,-101.11
@@ -329,11 +329,11 @@ MB327,McTavish,,Manitoba,CA,49.4589,-97.3689
 MB328,Meadow Portage,,Manitoba,CA,51.6681,-99.6072
 MB329,Medora,,Manitoba,CA,49.256,-100.696
 MB330,Meleb,,Manitoba,CA,50.7286,-97.2167
-MB331,Melita,,Manitoba,CA,49.2744,-100.98700000000001
+MB331,Melita,,Manitoba,CA,49.2744,-100.987
 MB332,Menzie,,Manitoba,CA,50.5314,-100.49
 MB333,Miami,,Manitoba,CA,49.3711,-98.2439
 MB334,Middlebro,,Manitoba,CA,49.0205,-95.439
-MB335,Millwood,,Manitoba,CA,50.6958,-101.40799999999999
+MB335,Millwood,,Manitoba,CA,50.6958,-101.408
 MB336,Milner Ridge,,Manitoba,CA,50.1717,-96.2386
 MB337,Miniota,,Manitoba,CA,50.1429,-101.035
 MB338,Minitonas,,Manitoba,CA,52.0861,-101.039
@@ -351,7 +351,7 @@ MB349,Morweena,,Manitoba,CA,50.995,-97.4089
 MB350,Mosakahiken,,Manitoba,CA,53.7027,-100.329
 MB351,Mulvihill,,Manitoba,CA,50.9667,-98.1797
 MB352,Myrtle,,Manitoba,CA,49.3533,-97.8367
-MB353,Napinka,,Manitoba,CA,49.3225,-100.84100000000001
+MB353,Napinka,,Manitoba,CA,49.3225,-100.841
 MB354,Narcisse,,Manitoba,CA,50.6833,-97.5297
 MB355,Neelin,,Manitoba,CA,49.2294,-99.3478
 MB356,Neepawa,,Manitoba,CA,50.2287,-99.4746
@@ -362,7 +362,7 @@ MB360,Netley,,Manitoba,CA,50.3583,-96.9572
 MB361,Neubergthal,,Manitoba,CA,49.0747,-97.4811
 MB362,Neuenburg,,Manitoba,CA,49.0894,-97.9078
 MB363,New Bothwell,,Manitoba,CA,49.5906,-96.8903
-MB364,Newdale,,Manitoba,CA,50.3517,-100.20299999999999
+MB364,Newdale,,Manitoba,CA,50.3517,-100.203
 MB365,Newton,,Manitoba,CA,49.9275,-98.0781
 MB366,Ninette,,Manitoba,CA,49.4012,-99.6313
 MB367,Ninga,,Manitoba,CA,49.2275,-99.8894
@@ -410,9 +410,9 @@ MB408,Pikwitonei,,Manitoba,CA,55.5878,-97.1556
 MB409,Pilot Mound,,Manitoba,CA,49.2024,-98.8976
 MB410,Pinawa,,Manitoba,CA,50.1489,-95.8806
 MB411,Pinawa Bay,,Manitoba,CA,50.3199,-95.7945
-MB412,Pine Creek,,Manitoba,CA,52.0599,-100.17200000000001
+MB412,Pine Creek,,Manitoba,CA,52.0599,-100.172
 MB413,Pine Dock,,Manitoba,CA,51.6417,-96.8056
-MB414,Pine Falls,,Manitoba,CA,50.56399999999999,-96.2169
+MB414,Pine Falls,,Manitoba,CA,50.564,-96.2169
 MB415,Pine River,,Manitoba,CA,51.7842,-100.531
 MB416,Piney,,Manitoba,CA,49.0753,-95.9783
 MB417,Pipestone,,Manitoba,CA,49.5578,-100.946
@@ -439,19 +439,19 @@ MB437,Red Rock Lake,,Manitoba,CA,49.9869,-95.5194
 MB438,Red Rose,,Manitoba,CA,51.4663,-97.5316
 MB439,Red Sucker Lake,,Manitoba,CA,54.1647,-93.5589
 MB440,Reeder,,Manitoba,CA,50.1069,-101.148
-MB441,Regent,,Manitoba,CA,49.3408,-100.31200000000001
+MB441,Regent,,Manitoba,CA,49.3408,-100.312
 MB442,Reinland,,Manitoba,CA,49.0417,-97.8714
 MB443,Rennie,,Manitoba,CA,49.8528,-95.5528
-MB444,Renwer,,Manitoba,CA,52.0984,-100.81700000000001
-MB445,Reston,,Manitoba,CA,49.5575,-101.09299999999999
+MB444,Renwer,,Manitoba,CA,52.0984,-100.817
+MB445,Reston,,Manitoba,CA,49.5575,-101.093
 MB446,Reykjavik,,Manitoba,CA,51.1986,-98.9025
 MB447,Richer,,Manitoba,CA,49.6575,-96.4569
 MB448,Ridgeville,,Manitoba,CA,49.0658,-97.0119
 MB449,Riding Mountain,,Manitoba,CA,50.5319,-99.4661
 MB450,River Hills,,Manitoba,CA,50.0761,-96.0269
-MB451,Rivers,,Manitoba,CA,50.0308,-100.23899999999999
+MB451,Rivers,,Manitoba,CA,50.0308,-100.239
 MB452,Riverton,,Manitoba,CA,50.9966,-97.001
-MB453,Roblin,,Manitoba,CA,51.23,-101.35600000000001
+MB453,Roblin,,Manitoba,CA,51.23,-101.356
 MB454,Rock Ridge,,Manitoba,CA,51.9172,-99.5799
 MB455,Roland,,Manitoba,CA,49.3664,-97.94
 MB456,Rolling River,,Manitoba,CA,50.4551,-99.9957
@@ -460,7 +460,7 @@ MB458,Roseau River,,Manitoba,CA,49.1842,-96.8256
 MB459,Roseau River Anishinabe,,Manitoba,CA,49.2108,-96.9397
 MB460,Rosebank,,Manitoba,CA,49.3706,-98.1133
 MB461,Roseisle,,Manitoba,CA,49.5,-98.3442
-MB462,Roseland,,Manitoba,CA,49.7981,-100.07600000000001
+MB462,Roseland,,Manitoba,CA,49.7981,-100.076
 MB463,Rosenfeld,,Manitoba,CA,49.1992,-97.5489
 MB464,Rosengart,,Manitoba,CA,49.0192,-97.8606
 MB465,Rosenort,,Manitoba,CA,49.4586,-97.4342
@@ -469,7 +469,7 @@ MB467,Ross,,Manitoba,CA,49.7606,-96.4331
 MB468,Rossburn,,Manitoba,CA,50.6692,-100.811
 MB469,Rossendale,,Manitoba,CA,49.8267,-98.6194
 MB470,Rossville,,Manitoba,CA,53.9984,-97.7766
-MB471,Russell,,Manitoba,CA,50.7808,-101.28399999999999
+MB471,Russell,,Manitoba,CA,50.7808,-101.284
 MB472,Salt Point,,Manitoba,CA,51.7531,-99.8125
 MB473,San Clara,,Manitoba,CA,51.4933,-101.428
 MB474,Sandilands,,Manitoba,CA,49.3285,-96.2981
@@ -486,22 +486,22 @@ MB484,Seddons Corner,,Manitoba,CA,50.0619,-96.2908
 MB485,Selkirk,,Manitoba,CA,50.1436,-96.8839
 MB486,Seven Sisters Falls,,Manitoba,CA,50.1058,-96.0156
 MB487,Seymourville,,Manitoba,CA,51.1844,-96.3279
-MB488,Shamattawa,,Manitoba,CA,55.86600000000001,-92.0999
+MB488,Shamattawa,,Manitoba,CA,55.866,-92.0999
 MB489,Shellmouth,,Manitoba,CA,50.9347,-101.479
 MB490,Sherridon,,Manitoba,CA,55.1242,-101.11
 MB491,Shevlin,,Manitoba,CA,51.1939,-101.208
 MB492,Shilo,,Manitoba,CA,49.8063,-99.6468
-MB493,Shoal Lake,,Manitoba,CA,50.4378,-100.59100000000001
+MB493,Shoal Lake,,Manitoba,CA,50.4378,-100.591
 MB494,Shoal River,,Manitoba,CA,52.7532,-100.679
 MB495,Sidney,,Manitoba,CA,49.9,-99.0789
-MB496,Sifton,,Manitoba,CA,51.3603,-100.14200000000001
+MB496,Sifton,,Manitoba,CA,51.3603,-100.142
 MB497,Silver,,Manitoba,CA,50.8458,-97.2175
 MB498,Silver Falls,,Manitoba,CA,50.515,-96.0989
 MB499,Silver Harbour,,Manitoba,CA,50.8106,-96.9675
-MB500,Silverton,,Manitoba,CA,50.7669,-101.15899999999999
+MB500,Silverton,,Manitoba,CA,50.7669,-101.159
 MB501,Sinclair,,Manitoba,CA,49.5692,-101.288
-MB502,Sioux Valley,,Manitoba,CA,49.8614,-100.48700000000001
-MB503,Snow Lake,,Manitoba,CA,54.8754,-100.01799999999999
+MB502,Sioux Valley,,Manitoba,CA,49.8614,-100.487
+MB503,Snow Lake,,Manitoba,CA,54.8754,-100.018
 MB504,Snowflake,,Manitoba,CA,49.0475,-98.6592
 MB505,Solsgirth,,Manitoba,CA,50.4903,-100.914
 MB506,Somerset,,Manitoba,CA,49.4109,-98.6593
@@ -559,7 +559,7 @@ MB557,Stuartburn,,Manitoba,CA,49.1336,-96.7631
 MB558,Sundown,,Manitoba,CA,49.1036,-96.2667
 MB559,Swan Lake,,Manitoba,CA,49.4117,-98.7914
 MB560,Swan Lake Reserve,,Manitoba,CA,49.3875,-98.8847
-MB561,Swan River,,Manitoba,CA,52.1094,-101.26299999999999
+MB561,Swan River,,Manitoba,CA,52.1094,-101.263
 MB562,Tadoule Lake,,Manitoba,CA,58.7174,-98.4827
 MB563,Tenby,,Manitoba,CA,50.4997,-99.1275
 MB564,Teulon,,Manitoba,CA,50.3858,-97.2611
@@ -568,20 +568,20 @@ MB566,The Pas,,Manitoba,CA,53.8151,-101.245
 MB567,Thicket Portage,,Manitoba,CA,55.3221,-97.6827
 MB568,Thompson,,Manitoba,CA,55.7433,-97.8553
 MB569,Thornhill,,Manitoba,CA,49.2003,-98.2317
-MB570,Tilston,,Manitoba,CA,49.3936,-101.31299999999999
+MB570,Tilston,,Manitoba,CA,49.3936,-101.313
 MB571,Tolstoi,,Manitoba,CA,49.0744,-96.8111
 MB572,Toutes Aides,,Manitoba,CA,51.485,-99.5317
 MB573,Transcona,,Manitoba,CA,49.9037,-96.9853
 MB574,Treesbank,,Manitoba,CA,49.6361,-99.6094
 MB575,Treherne,,Manitoba,CA,49.6281,-98.7131
 MB576,Tyndall,,Manitoba,CA,50.0837,-96.662
-MB577,Umpherville,,Manitoba,CA,53.8346,-101.22200000000001
-MB578,Valley River,,Manitoba,CA,51.2481,-100.14299999999999
-MB579,Valley River Reserve,,Manitoba,CA,51.2293,-100.96700000000001
+MB577,Umpherville,,Manitoba,CA,53.8346,-101.222
+MB578,Valley River,,Manitoba,CA,51.2481,-100.143
+MB579,Valley River Reserve,,Manitoba,CA,51.2293,-100.967
 MB580,Vassar,,Manitoba,CA,49.0978,-95.8314
 MB581,Victoria Beach,,Manitoba,CA,50.7065,-96.5598
 MB582,Virden,,Manitoba,CA,49.8508,-100.932
-MB583,Vista,,Manitoba,CA,50.6203,-100.71799999999999
+MB583,Vista,,Manitoba,CA,50.6203,-100.718
 MB584,Vita,,Manitoba,CA,49.1339,-96.5614
 MB585,Vivian,,Manitoba,CA,49.8847,-96.4575
 MB586,Vogar,,Manitoba,CA,50.9519,-98.645
@@ -614,4 +614,4 @@ MB612,Woodnorth,,Manitoba,CA,49.7325,-101.081
 MB613,Woodridge,,Manitoba,CA,49.2839,-96.1478
 MB614,Woodside,,Manitoba,CA,50.1814,-98.7772
 MB615,York Landing,,Manitoba,CA,56.0906,-96.0999
-MB616,Young Point,,Manitoba,CA,53.7512,-101.24799999999999
+MB616,Young Point,,Manitoba,CA,53.7512,-101.248

--- a/vector_data/point/northwest_territories_point_locations.csv
+++ b/vector_data/point/northwest_territories_point_locations.csv
@@ -14,7 +14,7 @@ NT12,Fort Good Hope,Rádeyîlîkóé,Northwest Territories,CA,66.257,-128.6377
 NT13,Fort Liard,Echaot'l Koe,Northwest Territories,CA,60.2392,-123.4752
 NT14,Fort McPherson,Teetł'it Zheh,Northwest Territories,CA,67.4365,-134.8833
 NT15,Fort Providence,Zhahti Koe,Northwest Territories,CA,61.3552,-117.6542
-NT16,Fort Resolution,Denı́nu Kų́ę́,Northwest Territories,CA,61.17100000000001,-113.6721
+NT16,Fort Resolution,Denı́nu Kų́ę́,Northwest Territories,CA,61.171,-113.6721
 NT17,Fort Simpson,Łı́ı́dlı̨ı̨ Kų́ę́,Northwest Territories,CA,61.8609,-121.3527
 NT18,Fort Smith,Thebacha,Northwest Territories,CA,60.0053,-111.8829
 NT19,Gahcho Kue Mine,,Northwest Territories,CA,63.5047,-109.0461

--- a/vector_data/point/saskatchewan_point_locations.csv
+++ b/vector_data/point/saskatchewan_point_locations.csv
@@ -4,14 +4,14 @@ SK2,Aberdeen,,Saskatchewan,CA,52.327,-106.288
 SK3,Aberfeldy,,Saskatchewan,CA,53.25,-109.883
 SK4,Abernethy,,Saskatchewan,CA,50.7474,-103.416
 SK5,Admiral,,Saskatchewan,CA,49.7134,-108.006
-SK6,Air Ronge,,Saskatchewan,CA,55.0833,-105.31700000000001
-SK7,Alameda,,Saskatchewan,CA,49.2667,-102.28299999999999
+SK6,Air Ronge,,Saskatchewan,CA,55.0833,-105.317
+SK7,Alameda,,Saskatchewan,CA,49.2667,-102.283
 SK8,Albertville,,Saskatchewan,CA,53.3963,-105.541
 SK9,Alice Beach,,Saskatchewan,CA,50.9257,-105.165
-SK10,Alida,,Saskatchewan,CA,49.388999999999996,-101.874
+SK10,Alida,,Saskatchewan,CA,49.389,-101.874
 SK11,Allan,,Saskatchewan,CA,51.8952,-106.053
-SK12,Alta Vista,,Saskatchewan,CA,50.8035,-104.96799999999999
-SK13,Alticane,,Saskatchewan,CA,52.9015,-107.48100000000001
+SK12,Alta Vista,,Saskatchewan,CA,50.8035,-104.968
+SK13,Alticane,,Saskatchewan,CA,52.9015,-107.481
 SK14,Alvena,,Saskatchewan,CA,52.5176,-106.02
 SK15,Amazon,,Saskatchewan,CA,51.55,-105.45
 SK16,Amsterdam,,Saskatchewan,CA,51.7488,-102.46
@@ -20,61 +20,61 @@ SK18,Annaheim,,Saskatchewan,CA,52.32,-104.818
 SK19,Antler,,Saskatchewan,CA,49.5675,-101.458
 SK20,Aquadeo,,Saskatchewan,CA,53.1319,-108.42
 SK21,Arborfield,,Saskatchewan,CA,53.1061,-103.661
-SK22,Archerwill,,Saskatchewan,CA,52.43899999999999,-103.859
+SK22,Archerwill,,Saskatchewan,CA,52.439,-103.859
 SK23,Arcola,,Saskatchewan,CA,49.6377,-102.492
 SK24,Ardill,,Saskatchewan,CA,49.9377,-105.844
-SK25,Arlington Beach,,Saskatchewan,CA,51.2479,-105.23100000000001
-SK26,Armit,,Saskatchewan,CA,52.8333,-101.78299999999999
-SK27,Armley,,Saskatchewan,CA,53.1167,-104.03299999999999
-SK28,Arran,,Saskatchewan,CA,51.8833,-101.71700000000001
+SK25,Arlington Beach,,Saskatchewan,CA,51.2479,-105.231
+SK26,Armit,,Saskatchewan,CA,52.8333,-101.783
+SK27,Armley,,Saskatchewan,CA,53.1167,-104.033
+SK28,Arran,,Saskatchewan,CA,51.8833,-101.717
 SK29,Asquith,,Saskatchewan,CA,52.1336,-107.226
-SK30,Assiniboia,,Saskatchewan,CA,49.6305,-105.98700000000001
+SK30,Assiniboia,,Saskatchewan,CA,49.6305,-105.987
 SK31,Atwater,,Saskatchewan,CA,50.7768,-102.227
-SK32,Auburnton,,Saskatchewan,CA,49.4048,-102.07700000000001
+SK32,Auburnton,,Saskatchewan,CA,49.4048,-102.077
 SK33,Avonlea,,Saskatchewan,CA,50.0156,-105.056
-SK34,Aylesbury,,Saskatchewan,CA,50.9395,-105.69200000000001
+SK34,Aylesbury,,Saskatchewan,CA,50.9395,-105.692
 SK35,Aylsham,,Saskatchewan,CA,53.1937,-103.805
-SK36,B-Say-Tah,,Saskatchewan,CA,50.7868,-103.85799999999999
+SK36,B-Say-Tah,,Saskatchewan,CA,50.7868,-103.858
 SK37,Badgerville,,Saskatchewan,CA,51.6336,-101.912
 SK38,Balcarres,,Saskatchewan,CA,50.8035,-103.546
 SK39,Baldwinton,,Saskatchewan,CA,52.7888,-109.256
 SK40,Balgonie,,Saskatchewan,CA,50.4893,-104.265
 SK41,Balone Beach,,Saskatchewan,CA,52.6679,-105.602
-SK42,Bangor,,Saskatchewan,CA,50.8073,-102.34200000000001
+SK42,Bangor,,Saskatchewan,CA,50.8073,-102.342
 SK43,Bankend,,Saskatchewan,CA,51.5098,-103.848
-SK44,Bapaume,,Saskatchewan,CA,53.3833,-107.67399999999999
+SK44,Bapaume,,Saskatchewan,CA,53.3833,-107.674
 SK45,Barrier Ford,,Saskatchewan,CA,52.5405,-103.706
-SK46,Battleford,,Saskatchewan,CA,52.7382,-108.30799999999999
+SK46,Battleford,,Saskatchewan,CA,52.7382,-108.308
 SK47,Bayard,,Saskatchewan,CA,50.0204,-105.289
 SK48,Beacon Hill,,Saskatchewan,CA,54.3546,-109.654
-SK49,Beadle,,Saskatchewan,CA,51.4671,-109.00399999999999
+SK49,Beadle,,Saskatchewan,CA,51.4671,-109.004
 SK50,Bear Creek,,Saskatchewan,CA,56.2975,-108.936
 SK51,Beardy's 97 and Okemasis' 96,,Saskatchewan,CA,52.8129,-106.3484
 SK52,Beatty,,Saskatchewan,CA,52.9001,-104.805
-SK53,Beaubier,,Saskatchewan,CA,49.1263,-104.07799999999999
+SK53,Beaubier,,Saskatchewan,CA,49.1263,-104.078
 SK54,Beauval,,Saskatchewan,CA,55.1472,-107.611
 SK55,Beaver Creek,,Saskatchewan,CA,51.9729,-106.669
 SK56,Beaver Flat,,Saskatchewan,CA,50.6604,-107.656
 SK57,Beechy,,Saskatchewan,CA,50.8833,-107.383
-SK58,Belbutte,,Saskatchewan,CA,53.3667,-107.81700000000001
+SK58,Belbutte,,Saskatchewan,CA,53.3667,-107.817
 SK59,Belle Plaine,,Saskatchewan,CA,50.3945,-105.156
-SK60,Bellegarde,,Saskatchewan,CA,49.5308,-101.54899999999999
-SK61,Bengough,,Saskatchewan,CA,49.396,-105.12700000000001
-SK62,Benson,,Saskatchewan,CA,49.4551,-103.00399999999999
+SK60,Bellegarde,,Saskatchewan,CA,49.5308,-101.549
+SK61,Bengough,,Saskatchewan,CA,49.396,-105.127
+SK62,Benson,,Saskatchewan,CA,49.4551,-103.004
 SK63,Bertwell,,Saskatchewan,CA,52.5886,-102.545
-SK64,Bethune,,Saskatchewan,CA,50.7129,-105.20700000000001
+SK64,Bethune,,Saskatchewan,CA,50.7129,-105.207
 SK65,Beverley,,Saskatchewan,CA,50.2685,-107.98
 SK66,Bienfait,,Saskatchewan,CA,49.1423,-102.805
 SK67,Big Beaver,,Saskatchewan,CA,49.1006,-105.171
-SK68,Big Island Lake,,Saskatchewan,CA,54.4290769,-109.6600491
-SK69,Big River,,Saskatchewan,CA,53.8348,-107.03399999999999
-SK70,Big Shell,,Saskatchewan,CA,53.2004,-107.12899999999999
+SK68,Big Island Lake,,Saskatchewan,CA,54.4291,-109.66
+SK69,Big River,,Saskatchewan,CA,53.8348,-107.034
+SK70,Big Shell,,Saskatchewan,CA,53.2004,-107.129
 SK71,Biggar,,Saskatchewan,CA,52.058,-107.985
-SK72,Birch Hills,,Saskatchewan,CA,52.983000000000004,-105.435
+SK72,Birch Hills,,Saskatchewan,CA,52.983,-105.435
 SK73,Birch Narrows,,Saskatchewan,CA,56.4703,-108.689
 SK74,Bird's Point,,Saskatchewan,CA,50.5465,-102.368
-SK75,Birmingham,,Saskatchewan,CA,50.9735,-102.93799999999999
-SK76,Birsay,,Saskatchewan,CA,51.0976,-106.98100000000001
+SK75,Birmingham,,Saskatchewan,CA,50.9735,-102.938
+SK76,Birsay,,Saskatchewan,CA,51.0976,-106.981
 SK77,Bjorkdale,,Saskatchewan,CA,52.7107,-103.646
 SK78,Black Lake,,Saskatchewan,CA,59.1333,-105.6
 SK79,Black Point,,Saskatchewan,CA,56.3667,-109.45
@@ -82,87 +82,87 @@ SK80,Bladworth,,Saskatchewan,CA,51.3669,-106.137
 SK81,Blaine Lake,,Saskatchewan,CA,52.8302,-106.881
 SK82,Blumenheim,,Saskatchewan,CA,52.3896,-106.417
 SK83,Blumenhof,,Saskatchewan,CA,50.0229,-107.7
-SK84,Blumenthal,,Saskatchewan,CA,52.4818,-106.37700000000001
+SK84,Blumenthal,,Saskatchewan,CA,52.4818,-106.377
 SK85,Bodmin,,Saskatchewan,CA,53.7544,-106.986
-SK86,Boharm,,Saskatchewan,CA,50.4,-105.71700000000001
+SK86,Boharm,,Saskatchewan,CA,50.4,-105.717
 SK87,Borden,,Saskatchewan,CA,52.4056,-107.238
 SK88,Brabant Lake,,Saskatchewan,CA,56.1167,-103.75
 SK89,Bracken,,Saskatchewan,CA,49.1782,-108.096
-SK90,Bradwell,,Saskatchewan,CA,51.9477,-106.23200000000001
-SK91,Brancepeth,,Saskatchewan,CA,53.001999999999995,-105.262
-SK92,Bredenbury,,Saskatchewan,CA,50.9435,-102.04899999999999
-SK93,Brewer,,Saskatchewan,CA,50.9871502,-102.72730849999999
-SK94,Briercrest,,Saskatchewan,CA,50.1667,-105.26700000000001
+SK90,Bradwell,,Saskatchewan,CA,51.9477,-106.232
+SK91,Brancepeth,,Saskatchewan,CA,53.002,-105.262
+SK92,Bredenbury,,Saskatchewan,CA,50.9435,-102.049
+SK93,Brewer,,Saskatchewan,CA,50.9872,-102.7273
+SK94,Briercrest,,Saskatchewan,CA,50.1667,-105.267
 SK95,Broadview,,Saskatchewan,CA,50.3793,-102.58
 SK96,Brock,,Saskatchewan,CA,51.4421,-108.72
 SK97,Broderick,,Saskatchewan,CA,51.4883,-106.919
-SK98,Brownlee,,Saskatchewan,CA,50.7371,-106.01799999999999
+SK98,Brownlee,,Saskatchewan,CA,50.7371,-106.018
 SK99,Bruno,,Saskatchewan,CA,52.2632,-105.524
 SK100,Buchanan,,Saskatchewan,CA,51.7,-102.75
-SK101,Buena Vista,,Saskatchewan,CA,50.7821,-104.94200000000001
-SK102,Buffalo Narrows,,Saskatchewan,CA,55.8661,-108.48899999999999
+SK101,Buena Vista,,Saskatchewan,CA,50.7821,-104.942
+SK102,Buffalo Narrows,,Saskatchewan,CA,55.8661,-108.489
 SK103,Bulyea,,Saskatchewan,CA,50.9854,-104.863
-SK104,Burgis Beach,,Saskatchewan,CA,51.5431,-102.62200000000001
+SK104,Burgis Beach,,Saskatchewan,CA,51.5431,-102.622
 SK105,Burr,,Saskatchewan,CA,52.042,105.135
-SK106,Burstall,,Saskatchewan,CA,50.6559,-109.90799999999999
+SK106,Burstall,,Saskatchewan,CA,50.6559,-109.908
 SK107,Bushell Park,,Saskatchewan,CA,50.3396,-105.552
 SK108,Cabri,,Saskatchewan,CA,50.6194,-108.461
-SK109,Cadillac,,Saskatchewan,CA,49.7259,-107.73700000000001
+SK109,Cadillac,,Saskatchewan,CA,49.7259,-107.737
 SK110,Calder,,Saskatchewan,CA,51.1579,-101.749
 SK111,Camp Dundurn,,Saskatchewan,CA,51.8522,-106.555
 SK112,Camsell Portage,,Saskatchewan,CA,59.6093,-109.264
-SK113,Cana,,Saskatchewan,CA,50.8854,-102.64299999999999
+SK113,Cana,,Saskatchewan,CA,50.8854,-102.643
 SK114,Candiac,,Saskatchewan,CA,50.2111,-103.259
-SK115,Candle Lake,,Saskatchewan,CA,53.7517,-105.25200000000001
+SK115,Candle Lake,,Saskatchewan,CA,53.7517,-105.252
 SK116,Cando,,Saskatchewan,CA,52.3731,-108.215
 SK117,Cannington Lake,,Saskatchewan,CA,49.7838,-102.162
 SK118,Canoe Lake 165,,Saskatchewan,CA,54.1018,-108.085
-SK119,Canoe Narrows,,Saskatchewan,CA,55.1634,-108.15700000000001
-SK120,Canora,,Saskatchewan,CA,51.6333,-102.43299999999999
+SK119,Canoe Narrows,,Saskatchewan,CA,55.1634,-108.157
+SK120,Canora,,Saskatchewan,CA,51.6333,-102.433
 SK121,Cantuar,,Saskatchewan,CA,50.383,-108.009
 SK122,Canwood,,Saskatchewan,CA,53.3616,-106.604
 SK123,Carievale,,Saskatchewan,CA,49.1743,-101.624
 SK124,Carlea,,Saskatchewan,CA,53.15,-103.9
-SK125,Carlyle,,Saskatchewan,CA,49.6333,-102.26700000000001
+SK125,Carlyle,,Saskatchewan,CA,49.6333,-102.267
 SK126,Carlyle Lake Resort,,Saskatchewan,CA,49.7418,-102.274
-SK127,Carmel,,Saskatchewan,CA,52.2248,-105.34899999999999
+SK127,Carmel,,Saskatchewan,CA,52.2248,-105.349
 SK128,Carmichael,,Saskatchewan,CA,50.0455,-108.648
 SK129,Carnduff,,Saskatchewan,CA,49.1749,-101.794
 SK130,Caron,,Saskatchewan,CA,50.4582,-105.874
-SK131,Caronport,,Saskatchewan,CA,50.458999999999996,-105.815
+SK131,Caronport,,Saskatchewan,CA,50.459,-105.815
 SK132,Carrot River,,Saskatchewan,CA,53.2833,-103.583
-SK133,Carry The Kettle,,Saskatchewan,CA,50.3522,-103.46799999999999
+SK133,Carry The Kettle,,Saskatchewan,CA,50.3522,-103.468
 SK134,Casa Rio,,Saskatchewan,CA,52.0275,-106.646
 SK135,Cedar Villa Estates,,Saskatchewan,CA,52.0965,-106.772
 SK136,Cedoux,,Saskatchewan,CA,49.8833,-103.867
 SK137,Central Butte,,Saskatchewan,CA,50.7976,-106.507
 SK138,Ceylon,,Saskatchewan,CA,49.4587,-104.601
-SK139,Chamberlain,,Saskatchewan,CA,50.85,-105.56700000000001
-SK140,Chaplin,,Saskatchewan,CA,50.4616,-106.65799999999999
-SK141,Chelan,,Saskatchewan,CA,52.6105,-103.39299999999999
-SK142,Chitek Lake,,Saskatchewan,CA,53.7538,-107.73100000000001
+SK139,Chamberlain,,Saskatchewan,CA,50.85,-105.567
+SK140,Chaplin,,Saskatchewan,CA,50.4616,-106.658
+SK141,Chelan,,Saskatchewan,CA,52.6105,-103.393
+SK142,Chitek Lake,,Saskatchewan,CA,53.7538,-107.731
 SK143,Choiceland,,Saskatchewan,CA,53.4924,-104.484
 SK144,Chorney Beach,,Saskatchewan,CA,51.8064,-103.553
 SK145,Chortitz,,Saskatchewan,CA,50.1056,-107.645
 SK146,Christopher Lake,,Saskatchewan,CA,53.5402,-105.791
 SK147,Churchbridge,,Saskatchewan,CA,50.8977,-101.891
-SK148,Clair,,Saskatchewan,CA,52.0222,-104.07700000000001
+SK148,Clair,,Saskatchewan,CA,52.0222,-104.077
 SK149,Clavet,,Saskatchewan,CA,51.9957,-106.374
-SK150,Claybank,,Saskatchewan,CA,50.0455,-105.23299999999999
+SK150,Claybank,,Saskatchewan,CA,50.0455,-105.233
 SK151,Clearwater River,,Saskatchewan,CA,56.5296,-109.492
-SK152,Clearwater River,,Saskatchewan,CA,56.0486,-108.72399999999999
+SK152,Clearwater River,,Saskatchewan,CA,56.0486,-108.724
 SK153,Clemenceau,,Saskatchewan,CA,52.6652,-102.527
-SK154,Climax,,Saskatchewan,CA,49.2077,-108.38799999999999
+SK154,Climax,,Saskatchewan,CA,49.2077,-108.388
 SK155,Clouston,,Saskatchewan,CA,53.1,-105.85
 SK156,Cluff Lake,,Saskatchewan,CA,58.3653,-109.531
 SK157,Cochin,,Saskatchewan,CA,53.0823,-108.337
 SK158,Coderre,,Saskatchewan,CA,50.1333,-106.383
-SK159,Codette,,Saskatchewan,CA,53.2815,-104.02799999999999
+SK159,Codette,,Saskatchewan,CA,53.2815,-104.028
 SK160,Cole Bay,,Saskatchewan,CA,55.0974,-108.322
 SK161,Colesdale Park,,Saskatchewan,CA,50.9523,-105.148
-SK162,Coleville,,Saskatchewan,CA,51.7105,-109.24600000000001
-SK163,Colfax,,Saskatchewan,CA,49.9445,-103.98200000000001
-SK164,Colgate,,Saskatchewan,CA,49.3993,-103.89200000000001
+SK162,Coleville,,Saskatchewan,CA,51.7105,-109.246
+SK163,Colfax,,Saskatchewan,CA,49.9445,-103.982
+SK164,Colgate,,Saskatchewan,CA,49.3993,-103.892
 SK165,Colonsay,,Saskatchewan,CA,51.9775,-105.87
 SK166,Congress,,Saskatchewan,CA,49.7539,-106.021
 SK167,Conquest,,Saskatchewan,CA,51.5306,-107.24
@@ -171,31 +171,31 @@ SK169,Corning,,Saskatchewan,CA,49.9582,-102.971
 SK170,Coronach,,Saskatchewan,CA,49.1114,-105.516
 SK171,Coteau Beach,,Saskatchewan,CA,51.1663,-106.825
 SK172,Cowessess 73,,Saskatchewan,CA,50.5106,-102.654
-SK173,Craik,,Saskatchewan,CA,51.05,-105.81700000000001
+SK173,Craik,,Saskatchewan,CA,51.05,-105.817
 SK174,Crane Valley,,Saskatchewan,CA,49.757,-105.527
 SK175,Craven,,Saskatchewan,CA,50.7084,-104.81
 SK176,Cree Lake,,Saskatchewan,CA,57.3562,-106.834
-SK177,Creelman,,Saskatchewan,CA,49.818000000000005,-103.31
+SK177,Creelman,,Saskatchewan,CA,49.818,-103.31
 SK178,Creighton,,Saskatchewan,CA,54.75,-101.9
-SK179,Crooked River,,Saskatchewan,CA,52.8551,-103.73299999999999
+SK179,Crooked River,,Saskatchewan,CA,52.8551,-103.733
 SK180,Crutwell,,Saskatchewan,CA,53.2193,-106.069
 SK181,Crystal Bay-Sunset,,Saskatchewan,CA,53.5426,-108.867
-SK182,Crystal Lake,,Saskatchewan,CA,51.85,-102.43299999999999
-SK183,Crystal Springs,,Saskatchewan,CA,52.8079,-105.36399999999999
+SK182,Crystal Lake,,Saskatchewan,CA,51.85,-102.433
+SK183,Crystal Springs,,Saskatchewan,CA,52.8079,-105.364
 SK184,Cudsaskwa Beach,,Saskatchewan,CA,52.6491,-105.637
-SK185,Cudworth,,Saskatchewan,CA,52.4915,-105.73299999999999
-SK186,Cumberland House,,Saskatchewan,CA,53.9538,-102.26899999999999
+SK185,Cudworth,,Saskatchewan,CA,52.4915,-105.733
+SK186,Cumberland House,,Saskatchewan,CA,53.9538,-102.269
 SK187,Cupar,,Saskatchewan,CA,50.9465,-104.212
-SK188,Cut Knife,,Saskatchewan,CA,52.745,-109.01799999999999
-SK189,D'Arcy,,Saskatchewan,CA,51.4667,-108.53299999999999
-SK190,Dafoe,,Saskatchewan,CA,51.7544,-104.52600000000001
+SK188,Cut Knife,,Saskatchewan,CA,52.745,-109.018
+SK189,D'Arcy,,Saskatchewan,CA,51.4667,-108.533
+SK190,Dafoe,,Saskatchewan,CA,51.7544,-104.526
 SK191,Dalmeny,,Saskatchewan,CA,52.3423,-106.773
 SK192,Dana,,Saskatchewan,CA,52.2884,-105.705
 SK193,Danbury,,Saskatchewan,CA,52.055,-102.265
 SK194,Darlings Beach,,Saskatchewan,CA,49.9791,-107.925
-SK195,Davidson,,Saskatchewan,CA,51.2633,-105.98899999999999
+SK195,Davidson,,Saskatchewan,CA,51.2633,-105.989
 SK196,Davin,,Saskatchewan,CA,50.3836,-104.109
-SK197,Davis,,Saskatchewan,CA,53.1104,-105.67200000000001
+SK197,Davis,,Saskatchewan,CA,53.1104,-105.672
 SK198,Day Star,,Saskatchewan,CA,51.5076,-104.223
 SK199,Day's Beach,,Saskatchewan,CA,53.0502,-108.335
 SK200,Debden,,Saskatchewan,CA,53.5265,-106.881
@@ -216,51 +216,51 @@ SK214,Dodsland,,Saskatchewan,CA,51.7997,-108.836
 SK215,Dollard,,Saskatchewan,CA,49.6167,-108.583
 SK216,Domremy,,Saskatchewan,CA,52.7886,-105.729
 SK217,Donavon,,Saskatchewan,CA,51.8,-107.133
-SK218,Dore Lake,,Saskatchewan,CA,54.6209,-107.40899999999999
+SK218,Dore Lake,,Saskatchewan,CA,54.6209,-107.409
 SK219,Dorintosh,,Saskatchewan,CA,54.3527,-108.625
 SK220,Drake,,Saskatchewan,CA,51.7468,-105.012
-SK221,Drinkwater,,Saskatchewan,CA,50.2967,-105.13600000000001
+SK221,Drinkwater,,Saskatchewan,CA,50.2967,-105.136
 SK222,Dubuc,,Saskatchewan,CA,50.6838,-102.476
 SK223,Duck Lake,,Saskatchewan,CA,52.8117,-106.227
-SK224,Duff,,Saskatchewan,CA,50.8741,-103.09100000000001
+SK224,Duff,,Saskatchewan,CA,50.8741,-103.091
 SK225,Dunblane,,Saskatchewan,CA,51.2023,-106.88
 SK226,Dundurn,,Saskatchewan,CA,51.8093,-106.507
 SK227,Dunfermline,,Saskatchewan,CA,52.1339,-107.039
-SK228,Dunkirk,,Saskatchewan,CA,50.0333,-105.71700000000001
+SK228,Dunkirk,,Saskatchewan,CA,50.0333,-105.717
 SK229,Duperow,,Saskatchewan,CA,51.97,-108.243
 SK230,Duval,,Saskatchewan,CA,51.1572,-104.991
 SK231,Dysart,,Saskatchewan,CA,50.9472,-104.036
 SK232,Eagle Ridge,,Saskatchewan,CA,52.1611,-106.492
 SK233,Earl Grey,,Saskatchewan,CA,50.9342,-104.71
-SK234,Eastend,,Saskatchewan,CA,49.5167,-108.81700000000001
+SK234,Eastend,,Saskatchewan,CA,49.5167,-108.817
 SK235,Eatonia,,Saskatchewan,CA,51.2234,-109.39
 SK236,Ebenezer,,Saskatchewan,CA,51.3696,-102.447
 SK237,Echo Bay,,Saskatchewan,CA,53.2167,-107.133
-SK238,Edam,,Saskatchewan,CA,53.1876,-108.76899999999999
+SK238,Edam,,Saskatchewan,CA,53.1876,-108.769
 SK239,Edenwold,,Saskatchewan,CA,50.6333,-104.25
 SK240,Edgeley,,Saskatchewan,CA,50.6377,-103.995
 SK241,Elbow,,Saskatchewan,CA,51.1212,-106.596
-SK242,Elbow Lake,,Saskatchewan,CA,52.4927,-101.71600000000001
+SK242,Elbow Lake,,Saskatchewan,CA,52.4927,-101.716
 SK243,Eldersley,,Saskatchewan,CA,52.8602,-103.818
 SK244,Eldorado,,Saskatchewan,CA,59.5516,-108.514
-SK245,Elfros,,Saskatchewan,CA,51.7418,-103.86399999999999
-SK246,Elrose,,Saskatchewan,CA,51.2,-108.03299999999999
-SK247,Elstow,,Saskatchewan,CA,51.9874,-106.05799999999999
-SK248,Emma Lake,,Saskatchewan,CA,53.562,-105.87200000000001
-SK249,Endeavour,,Saskatchewan,CA,52.1609,-102.65700000000001
+SK245,Elfros,,Saskatchewan,CA,51.7418,-103.864
+SK246,Elrose,,Saskatchewan,CA,51.2,-108.033
+SK247,Elstow,,Saskatchewan,CA,51.9874,-106.058
+SK248,Emma Lake,,Saskatchewan,CA,53.562,-105.872
+SK249,Endeavour,,Saskatchewan,CA,52.1609,-102.657
 SK250,Englefeld,,Saskatchewan,CA,52.162,-104.655
 SK251,English River,,Saskatchewan,CA,55.9169,-107.723
-SK252,Ernfold,,Saskatchewan,CA,50.4462,-106.89200000000001
-SK253,Erwood,,Saskatchewan,CA,52.8582,-102.18700000000001
+SK252,Ernfold,,Saskatchewan,CA,50.4462,-106.892
+SK253,Erwood,,Saskatchewan,CA,52.8582,-102.187
 SK254,Esk,,Saskatchewan,CA,51.8167,-104.85
 SK255,Espeseth Cove,,Saskatchewan,CA,50.5508,-102.4
 SK256,Esterhazy,,Saskatchewan,CA,50.6551,-102.074
-SK257,Estevan,,Saskatchewan,CA,49.1333,-102.98299999999999
-SK258,Estlin,,Saskatchewan,CA,50.2512,-104.52600000000001
+SK257,Estevan,,Saskatchewan,CA,49.1333,-102.983
+SK258,Estlin,,Saskatchewan,CA,50.2512,-104.526
 SK259,Eston,,Saskatchewan,CA,51.15,-108.75
 SK260,Ethelton,,Saskatchewan,CA,52.7866,-104.932
 SK261,Etomami,,Saskatchewan,CA,52.7312,-102.319
-SK262,Etters Beach,,Saskatchewan,CA,51.233999999999995,-105.289
+SK262,Etters Beach,,Saskatchewan,CA,51.234,-105.289
 SK263,Evergreen Acres,,Saskatchewan,CA,53.5162,-108.661
 SK264,Evergreen Brightsand,,Saskatchewan,CA,53.6144,-108.835
 SK265,Evesham,,Saskatchewan,CA,52.3911,-109.844
@@ -269,13 +269,13 @@ SK267,Fairholme,,Saskatchewan,CA,53.4277,-108.54
 SK268,Fairlight,,Saskatchewan,CA,49.8749,-101.68
 SK269,Fairy Glen,,Saskatchewan,CA,53.0348,-104.538
 SK270,Fenton,,Saskatchewan,CA,53.0161,-105.586
-SK271,Fenwood,,Saskatchewan,CA,51.0125,-103.04700000000001
-SK272,Ferland,,Saskatchewan,CA,49.4489,-106.95100000000001
+SK271,Fenwood,,Saskatchewan,CA,51.0125,-103.047
+SK272,Ferland,,Saskatchewan,CA,49.4489,-106.951
 SK273,Fielding,,Saskatchewan,CA,52.5184,-107.55
 SK274,Fife Lake,,Saskatchewan,CA,49.1949,-105.729
 SK275,Fillmore,,Saskatchewan,CA,49.8795,-103.434
 SK276,Findlater,,Saskatchewan,CA,50.7885,-105.402
-SK277,Fishing Lake,,Saskatchewan,CA,51.8625,-103.63600000000001
+SK277,Fishing Lake,,Saskatchewan,CA,51.8625,-103.636
 SK278,Fiske,,Saskatchewan,CA,51.4833,-108.4
 SK279,Flaxcombe,,Saskatchewan,CA,51.4785,-109.601
 SK280,Fleming,,Saskatchewan,CA,50.0735,-101.508
@@ -286,53 +286,53 @@ SK284,Forget,,Saskatchewan,CA,49.65,-102.867
 SK285,Fort Qu'Appelle,,Saskatchewan,CA,50.7669,-103.79
 SK286,Fort San,,Saskatchewan,CA,50.7879,-103.804
 SK287,Fort Walsh,,Saskatchewan,CA,49.5667,-109.883
-SK288,Fosston,,Saskatchewan,CA,52.1902,-103.81200000000001
-SK289,Fox Valley,,Saskatchewan,CA,50.4656,-109.48100000000001
+SK288,Fosston,,Saskatchewan,CA,52.1902,-103.812
+SK289,Fox Valley,,Saskatchewan,CA,50.4656,-109.481
 SK290,Francis,,Saskatchewan,CA,50.1,-103.867
 SK291,Frenchman Butte,,Saskatchewan,CA,53.5907,-109.633
 SK292,Frobisher,,Saskatchewan,CA,49.2092,-102.426
-SK293,Frontier,,Saskatchewan,CA,49.206,-108.56299999999999
-SK294,Fulda,,Saskatchewan,CA,52.35,-105.21700000000001
-SK295,Furdale,,Saskatchewan,CA,52.0781,-106.68799999999999
-SK296,Furness,,Saskatchewan,CA,53.1167,-109.96700000000001
+SK293,Frontier,,Saskatchewan,CA,49.206,-108.563
+SK294,Fulda,,Saskatchewan,CA,52.35,-105.217
+SK295,Furdale,,Saskatchewan,CA,52.0781,-106.688
+SK296,Furness,,Saskatchewan,CA,53.1167,-109.967
 SK297,Gainsborough,,Saskatchewan,CA,49.1791,-101.449
 SK298,Garrick,,Saskatchewan,CA,53.4917,-104.338
 SK299,Garson Lake,,Saskatchewan,CA,56.3127,-109.956
 SK300,Gerald,,Saskatchewan,CA,50.6662,-101.794
 SK301,Gibbs,,Saskatchewan,CA,50.9037,-104.866
 SK302,Girvin,,Saskatchewan,CA,51.1585,-105.912
-SK303,Gladmar,,Saskatchewan,CA,49.1641,-104.45299999999999
+SK303,Gladmar,,Saskatchewan,CA,49.1641,-104.453
 SK304,Glaslyn,,Saskatchewan,CA,53.3577,-108.353
-SK305,Glen Ewen,,Saskatchewan,CA,49.2077,-102.01299999999999
-SK306,Glen Harbour,,Saskatchewan,CA,50.8899,-105.09299999999999
+SK305,Glen Ewen,,Saskatchewan,CA,49.2077,-102.013
+SK306,Glen Harbour,,Saskatchewan,CA,50.8899,-105.093
 SK307,Glenavon,,Saskatchewan,CA,50.1961,-103.139
 SK308,Glenbain,,Saskatchewan,CA,49.8443,-107.021
 SK309,Glenside,,Saskatchewan,CA,51.4536,-106.807
-SK310,Glentworth,,Saskatchewan,CA,49.4241,-106.68299999999999
-SK311,Glidden,,Saskatchewan,CA,51.2398,-109.16799999999999
+SK310,Glentworth,,Saskatchewan,CA,49.4241,-106.683
+SK311,Glidden,,Saskatchewan,CA,51.2398,-109.168
 SK312,Golden Prairie,,Saskatchewan,CA,50.2213,-109.631
-SK313,Good Spirit Acres,,Saskatchewan,CA,51.4833,-102.68299999999999
+SK313,Good Spirit Acres,,Saskatchewan,CA,51.4833,-102.683
 SK314,Goodeve,,Saskatchewan,CA,51.0609,-103.182
-SK315,Goodsoil,,Saskatchewan,CA,54.3998,-109.23100000000001
+SK315,Goodsoil,,Saskatchewan,CA,54.3998,-109.231
 SK316,Goodwater,,Saskatchewan,CA,49.3959,-103.705
 SK317,Gordon 86,,Saskatchewan,CA,51.2735,-104.303
-SK318,Gouldtown,,Saskatchewan,CA,50.6167,-107.21700000000001
+SK318,Gouldtown,,Saskatchewan,CA,50.6167,-107.217
 SK319,Govan,,Saskatchewan,CA,51.3107,-104.993
-SK320,Grand Coulee,,Saskatchewan,CA,50.4333,-104.81700000000001
+SK320,Grand Coulee,,Saskatchewan,CA,50.4333,-104.817
 SK321,Grandora,,Saskatchewan,CA,52.1144,-106.98
 SK322,Grandview Beach,,Saskatchewan,CA,50.8747,-105.104
 SK323,Grasswood,,Saskatchewan,CA,52.0573,-106.647
 SK324,Gravelbourg,,Saskatchewan,CA,49.8771,-106.552
 SK325,Gray,,Saskatchewan,CA,50.1717,-104.445
-SK326,Grayson,,Saskatchewan,CA,50.7202,-102.64399999999999
+SK326,Grayson,,Saskatchewan,CA,50.7202,-102.644
 SK327,Green Lake,,Saskatchewan,CA,54.2908,-107.792
 SK328,Greenfeld,,Saskatchewan,CA,52.4365,-106.639
 SK329,Greenstreet,,Saskatchewan,CA,53.4614,-109.815
 SK330,Greig Lake,,Saskatchewan,CA,54.4433,-108.693
 SK331,Grenfell,,Saskatchewan,CA,50.4114,-102.931
-SK332,Griffin,,Saskatchewan,CA,49.6667,-103.43299999999999
+SK332,Griffin,,Saskatchewan,CA,49.6667,-103.433
 SK333,Gronlid,,Saskatchewan,CA,53.1016,-104.464
-SK334,Gruenthal,,Saskatchewan,CA,52.4634,-106.51899999999999
+SK334,Gruenthal,,Saskatchewan,CA,52.4634,-106.519
 SK335,Guernsey,,Saskatchewan,CA,51.8708,-105.186
 SK336,Gull Lake,,Saskatchewan,CA,50.0954,-108.485
 SK337,Hafford,,Saskatchewan,CA,52.7258,-107.353
@@ -340,31 +340,31 @@ SK338,Hagen,,Saskatchewan,CA,52.9384,-105.557
 SK339,Hague,,Saskatchewan,CA,52.5111,-106.417
 SK340,Halbrite,,Saskatchewan,CA,49.4897,-103.557
 SK341,Handel,,Saskatchewan,CA,52.0635,-108.694
-SK342,Hanley,,Saskatchewan,CA,51.6297,-106.43700000000001
+SK342,Hanley,,Saskatchewan,CA,51.6297,-106.437
 SK343,Harris,,Saskatchewan,CA,51.7348,-107.58
-SK344,Hatchet Lake,,Saskatchewan,CA,58.119,-103.13600000000001
-SK345,Hawarden,,Saskatchewan,CA,51.4149,-106.59899999999999
+SK344,Hatchet Lake,,Saskatchewan,CA,58.119,-103.136
+SK345,Hawarden,,Saskatchewan,CA,51.4149,-106.599
 SK346,Hazel Dell,,Saskatchewan,CA,51.977,-102.977
 SK347,Hazenmore,,Saskatchewan,CA,49.6874,-107.137
 SK348,Hazlet,,Saskatchewan,CA,50.4007,-108.595
 SK349,Hendon,,Saskatchewan,CA,52.0885,-103.829
-SK350,Henribourg,,Saskatchewan,CA,53.3947,-105.62700000000001
+SK350,Henribourg,,Saskatchewan,CA,53.3947,-105.627
 SK351,Hepburn,,Saskatchewan,CA,52.5229,-106.729
 SK352,Herbert,,Saskatchewan,CA,50.4277,-107.221
-SK353,Herschel,,Saskatchewan,CA,51.6383,-108.35600000000001
+SK353,Herschel,,Saskatchewan,CA,51.6383,-108.356
 SK354,Heward,,Saskatchewan,CA,49.7376,-103.15
 SK355,High Tor,,Saskatchewan,CA,52.4667,-103.3
 SK356,Hillmond,,Saskatchewan,CA,53.4278,-109.697
-SK357,Hirsch,,Saskatchewan,CA,49.1782,-102.59299999999999
+SK357,Hirsch,,Saskatchewan,CA,49.1782,-102.593
 SK358,Hitchcock,,Saskatchewan,CA,49.224,-103.124
 SK359,Hitchcock Bay,,Saskatchewan,CA,51.0472,-106.867
 SK360,Hodgeville,,Saskatchewan,CA,50.1134,-106.962
 SK361,Hoey,,Saskatchewan,CA,52.8679,-105.796
-SK362,Holbein,,Saskatchewan,CA,53.2275,-106.20200000000001
-SK363,Holdfast,,Saskatchewan,CA,50.9602,-105.41799999999999
-SK364,Hoosier,,Saskatchewan,CA,51.6341,-109.73700000000001
+SK362,Holbein,,Saskatchewan,CA,53.2275,-106.202
+SK363,Holdfast,,Saskatchewan,CA,50.9602,-105.418
+SK364,Hoosier,,Saskatchewan,CA,51.6341,-109.737
 SK365,Horizon,,Saskatchewan,CA,49.5193,-105.229
-SK366,Horseshoe Bay,,Saskatchewan,CA,53.61666700000001,-108.640556
+SK366,Horseshoe Bay,,Saskatchewan,CA,53.6167,-108.6406
 SK367,Hubbard,,Saskatchewan,CA,51.129,-103.369
 SK368,Hudson Bay,,Saskatchewan,CA,52.8556,-102.389
 SK369,Humboldt,,Saskatchewan,CA,52.2,-105.124
@@ -375,57 +375,57 @@ SK373,Île-à-la-Crosse,,Saskatchewan,CA,55.4493,-107.904
 SK374,Illerbrun,,Saskatchewan,CA,49.9333,-108.35
 SK375,Imperial,,Saskatchewan,CA,51.3466,-105.434
 SK376,Indian Head,,Saskatchewan,CA,50.5333,-103.667
-SK377,Indian Point - Golden Sands,,Saskatchewan,CA,53.5897,-108.59899999999999
+SK377,Indian Point - Golden Sands,,Saskatchewan,CA,53.5897,-108.599
 SK378,Invermay,,Saskatchewan,CA,51.8067,-103.156
 SK379,Island View,,Saskatchewan,CA,50.9731,-105.161
-SK380,Ituna,,Saskatchewan,CA,51.1698,-103.49700000000001
-SK381,James Smith,,Saskatchewan,CA,53.1025,-104.87100000000001
+SK380,Ituna,,Saskatchewan,CA,51.1698,-103.497
+SK381,James Smith,,Saskatchewan,CA,53.1025,-104.871
 SK382,Jameson,,Saskatchewan,CA,50.405,-104.287
-SK383,Jans Bay,,Saskatchewan,CA,55.1506,-108.09899999999999
+SK383,Jans Bay,,Saskatchewan,CA,55.1506,-108.099
 SK384,Jansen,,Saskatchewan,CA,51.7865,-104.715
 SK385,Jasmin,,Saskatchewan,CA,51.2281,-103.646
-SK386,Kahkewistahaw,,Saskatchewan,CA,50.4928,-102.53299999999999
+SK386,Kahkewistahaw,,Saskatchewan,CA,50.4928,-102.533
 SK387,Kamsack,,Saskatchewan,CA,51.5626,-101.898
-SK388,Kamsack Beach,,Saskatchewan,CA,51.6335,-101.65100000000001
+SK388,Kamsack Beach,,Saskatchewan,CA,51.6335,-101.651
 SK389,Kandahar,,Saskatchewan,CA,51.7589,-104.361
 SK390,Kannata Valley,,Saskatchewan,CA,50.7833,-104.9
-SK391,Katepwa Beach,,Saskatchewan,CA,50.696999999999996,-103.62700000000001
+SK391,Katepwa Beach,,Saskatchewan,CA,50.697,-103.627
 SK392,Katepwa South,,Saskatchewan,CA,50.6617,-103.64
 SK393,Kawacatoose,,Saskatchewan,CA,51.4775,-104.399
 SK394,Kayville,,Saskatchewan,CA,49.7264,-105.15
-SK395,Keatley,,Saskatchewan,CA,52.8,-107.46700000000001
-SK396,Kedleston Beach,,Saskatchewan,CA,50.8167,-105.06700000000001
+SK395,Keatley,,Saskatchewan,CA,52.8,-107.467
+SK396,Kedleston Beach,,Saskatchewan,CA,50.8167,-105.067
 SK397,Keeler,,Saskatchewan,CA,50.6833,-105.883
 SK398,Kelliher,,Saskatchewan,CA,51.2666,-103.734
-SK399,Kelso,,Saskatchewan,CA,49.9659,-101.95200000000001
+SK399,Kelso,,Saskatchewan,CA,49.9659,-101.952
 SK400,Kelvington,,Saskatchewan,CA,52.1617,-103.525
-SK401,Kenaston,,Saskatchewan,CA,51.5019,-106.26700000000001
+SK401,Kenaston,,Saskatchewan,CA,51.5019,-106.267
 SK402,Kendal,,Saskatchewan,CA,50.255,-103.615
-SK403,Kennedy,,Saskatchewan,CA,50.0134,-102.34899999999999
+SK403,Kennedy,,Saskatchewan,CA,50.0134,-102.349
 SK404,Kenosee Lake,,Saskatchewan,CA,49.8334,-102.285
 SK405,Kenosee Park,,Saskatchewan,CA,49.8339,-102.318
 SK406,Kerrobert,,Saskatchewan,CA,51.9167,-109.133
 SK407,Ketchen,,Saskatchewan,CA,51.9947,-102.821
 SK408,Key Lake,,Saskatchewan,CA,57.2226,-105.65
-SK409,Khedive,,Saskatchewan,CA,49.6167,-104.51700000000001
+SK409,Khedive,,Saskatchewan,CA,49.6167,-104.517
 SK410,Killaly,,Saskatchewan,CA,50.7566,-102.837
 SK411,Kilwinning,,Saskatchewan,CA,53.0998,-106.661
 SK412,Kincaid,,Saskatchewan,CA,49.6716,-107.005
-SK413,Kindersley,,Saskatchewan,CA,51.47,-109.15700000000001
+SK413,Kindersley,,Saskatchewan,CA,51.47,-109.157
 SK414,Kinistin Saulteaux,,Saskatchewan,CA,52.6083,-104.225
 SK415,Kinistino,,Saskatchewan,CA,52.9522,-105.029
 SK416,Kinley,,Saskatchewan,CA,52.0678,-107.427
 SK417,Kipling,,Saskatchewan,CA,50.1,-102.633
 SK418,Kisbey,,Saskatchewan,CA,49.65,-102.667
 SK419,Kivimaa-Moonlight Bay,,Saskatchewan,CA,53.6036,-108.665
-SK420,Kopp's Kove,,Saskatchewan,CA,53.5289,-108.69200000000001
+SK420,Kopp's Kove,,Saskatchewan,CA,53.5289,-108.692
 SK421,Kronau,,Saskatchewan,CA,50.3047,-104.294
 SK422,Krydor,,Saskatchewan,CA,52.7884,-107.075
 SK423,Kuroki,,Saskatchewan,CA,51.8694,-103.485
 SK424,Kyle,,Saskatchewan,CA,50.8319,-108.038
 SK425,Kylemore,,Saskatchewan,CA,51.9071,-103.641
 SK426,La Loche,,Saskatchewan,CA,56.4858,-109.434
-SK427,La Ronge,,Saskatchewan,CA,55.111999999999995,-105.3
+SK427,La Ronge,,Saskatchewan,CA,55.112,-105.3
 SK428,La Ronge,,Saskatchewan,CA,55.1072,-105.28
 SK429,Lac Vert,,Saskatchewan,CA,52.5035,-104.493
 SK430,Lady Lake,,Saskatchewan,CA,52.0268,-102.626
@@ -433,15 +433,15 @@ SK431,Lafleche,,Saskatchewan,CA,49.7052,-106.574
 SK432,Laird,,Saskatchewan,CA,52.7147,-106.589
 SK433,Lajord,,Saskatchewan,CA,50.2394,-104.147
 SK434,Lake Alma,,Saskatchewan,CA,49.1447,-104.197
-SK435,Lake Lenore,,Saskatchewan,CA,52.3969,-104.98299999999999
+SK435,Lake Lenore,,Saskatchewan,CA,52.3969,-104.983
 SK436,Lampman,,Saskatchewan,CA,49.3818,-102.756
 SK437,Lancer,,Saskatchewan,CA,50.8,-108.883
 SK438,Landis,,Saskatchewan,CA,52.2,-108.45
-SK439,Lang,,Saskatchewan,CA,49.9194,-104.37100000000001
+SK439,Lang,,Saskatchewan,CA,49.9194,-104.371
 SK440,Langbank,,Saskatchewan,CA,50.0491,-102.295
 SK441,Langenburg,,Saskatchewan,CA,50.8429,-101.7
 SK442,Langham,,Saskatchewan,CA,52.3609,-106.965
-SK443,Lanigan,,Saskatchewan,CA,51.85,-105.03299999999999
+SK443,Lanigan,,Saskatchewan,CA,51.85,-105.033
 SK444,Lanz Point,,Saskatchewan,CA,53.0294,-108.28
 SK445,Laporte,,Saskatchewan,CA,51.2145,-109.512
 SK446,Lashburn,,Saskatchewan,CA,53.1269,-109.613
@@ -455,64 +455,64 @@ SK453,Leoville,,Saskatchewan,CA,53.6333,-107.55
 SK454,Leross,,Saskatchewan,CA,51.2886,-103.87
 SK455,Leroy,,Saskatchewan,CA,52.0007,-104.738
 SK456,Leslie,,Saskatchewan,CA,51.6965,-103.713
-SK457,Leslie Beach,,Saskatchewan,CA,51.8159,-103.56299999999999
+SK457,Leslie Beach,,Saskatchewan,CA,51.8159,-103.563
 SK458,Lestock,,Saskatchewan,CA,51.3124,-103.98
 SK459,Liberty,,Saskatchewan,CA,51.1419,-105.444
-SK460,Limerick,,Saskatchewan,CA,49.6534,-106.26700000000001
+SK460,Limerick,,Saskatchewan,CA,49.6534,-106.267
 SK461,Lintlaw,,Saskatchewan,CA,52.0645,-103.244
-SK462,Lipton,,Saskatchewan,CA,50.9012,-103.84899999999999
+SK462,Lipton,,Saskatchewan,CA,50.9012,-103.849
 SK463,Lisieux,,Saskatchewan,CA,49.2785,-105.975
 SK464,Little Black Bear,,Saskatchewan,CA,51.0002,-103.348
 SK465,Little Fishing Lake,,Saskatchewan,CA,53.8591,-109.565
-SK466,Little Pine Indian Reserve 116,,Saskatchewan,CA,51.354179200000004,-110.63544309999999
+SK466,Little Pine Indian Reserve 116,,Saskatchewan,CA,51.3542,-110.6354
 SK467,Little Swan River,,Saskatchewan,CA,52.4013,-102.165
 SK468,Livelong,,Saskatchewan,CA,53.4485,-108.704
-SK469,Lockwood,,Saskatchewan,CA,51.65,-105.01700000000001
-SK470,Lone Rock,,Saskatchewan,CA,53.049,-109.87899999999999
+SK469,Lockwood,,Saskatchewan,CA,51.65,-105.017
+SK470,Lone Rock,,Saskatchewan,CA,53.049,-109.879
 SK471,Loon Lake,,Saskatchewan,CA,54.0265,-109.156
-SK472,Loreburn,,Saskatchewan,CA,51.2309,-106.59899999999999
-SK473,Love,,Saskatchewan,CA,53.486999999999995,-104.165
+SK472,Loreburn,,Saskatchewan,CA,51.2309,-106.599
+SK473,Love,,Saskatchewan,CA,53.487,-104.165
 SK474,Loverna,,Saskatchewan,CA,51.655,-109.99
 SK475,Lucky Lake,,Saskatchewan,CA,50.9833,-107.133
 SK476,Lumsden,,Saskatchewan,CA,50.6466,-104.868
 SK477,Lumsden Beach,,Saskatchewan,CA,50.7629,-104.902
 SK478,Luseland,,Saskatchewan,CA,52.0813,-109.39
 SK479,Macdowall,,Saskatchewan,CA,53.0169,-106.015
-SK480,Macklin,,Saskatchewan,CA,52.3333,-109.93700000000001
+SK480,Macklin,,Saskatchewan,CA,52.3333,-109.937
 SK481,MacNutt,,Saskatchewan,CA,51.0839,-101.604
-SK482,Macoun,,Saskatchewan,CA,49.315,-103.26299999999999
+SK482,Macoun,,Saskatchewan,CA,49.315,-103.263
 SK483,Macrorie,,Saskatchewan,CA,51.3261,-107.085
 SK484,Maidstone,,Saskatchewan,CA,53.0894,-109.288
 SK485,Main Centre,,Saskatchewan,CA,50.5822,-107.344
-SK486,Major,,Saskatchewan,CA,51.8724,-109.61399999999999
+SK486,Major,,Saskatchewan,CA,51.8724,-109.614
 SK487,Makwa,,Saskatchewan,CA,54.0059,-108.906
-SK488,Makwa Sahgaiehcan,,Saskatchewan,CA,54.038999999999994,-109.161
-SK489,Manitou Beach,,Saskatchewan,CA,51.7167,-105.43299999999999
+SK488,Makwa Sahgaiehcan,,Saskatchewan,CA,54.039,-109.161
+SK489,Manitou Beach,,Saskatchewan,CA,51.7167,-105.433
 SK490,Mankota,,Saskatchewan,CA,49.4199,-107.071
 SK491,Manor,,Saskatchewan,CA,49.6053,-102.085
 SK492,Mantario,,Saskatchewan,CA,51.2602,-109.695
 SK493,Maple Creek,,Saskatchewan,CA,49.9064,-109.48
 SK494,Marcelin,,Saskatchewan,CA,52.926,-106.794
-SK495,Marchwell,,Saskatchewan,CA,50.8013,-101.57600000000001
-SK496,Marengo,,Saskatchewan,CA,51.4794,-109.78299999999999
+SK495,Marchwell,,Saskatchewan,CA,50.8013,-101.576
+SK496,Marengo,,Saskatchewan,CA,51.4794,-109.783
 SK497,Margo,,Saskatchewan,CA,51.8251,-103.337
-SK498,Markinch,,Saskatchewan,CA,50.9396,-104.36200000000001
+SK498,Markinch,,Saskatchewan,CA,50.9396,-104.362
 SK499,Marquis,,Saskatchewan,CA,50.6195,-105.719
 SK500,Marsden,,Saskatchewan,CA,52.8393,-109.822
-SK501,Marshall,,Saskatchewan,CA,53.1935,-109.77799999999999
-SK502,Martensville,,Saskatchewan,CA,52.2922,-106.65799999999999
-SK503,Martinson's Beach,,Saskatchewan,CA,53.1,-108.43299999999999
-SK504,Maryfield,,Saskatchewan,CA,49.8369,-101.52600000000001
-SK505,Marysburg,,Saskatchewan,CA,52.318204200000004,-105.0935486
+SK501,Marshall,,Saskatchewan,CA,53.1935,-109.778
+SK502,Martensville,,Saskatchewan,CA,52.2922,-106.658
+SK503,Martinson's Beach,,Saskatchewan,CA,53.1,-108.433
+SK504,Maryfield,,Saskatchewan,CA,49.8369,-101.526
+SK505,Marysburg,,Saskatchewan,CA,52.3182,-105.0935
 SK506,Mayfair,,Saskatchewan,CA,52.9833,-107.6
-SK507,Maymont,,Saskatchewan,CA,52.5628,-107.70700000000001
-SK508,Mazenod,,Saskatchewan,CA,49.8627,-106.21700000000001
-SK509,McCord,,Saskatchewan,CA,49.428000000000004,-106.83
+SK507,Maymont,,Saskatchewan,CA,52.5628,-107.707
+SK508,Mazenod,,Saskatchewan,CA,49.8627,-106.217
+SK509,McCord,,Saskatchewan,CA,49.428,-106.83
 SK510,McGee,,Saskatchewan,CA,51.5029,-108.251
 SK511,McKague,,Saskatchewan,CA,52.6151,-103.941
-SK512,McLean,,Saskatchewan,CA,50.5167,-104.06700000000001
-SK513,McMahon,,Saskatchewan,CA,50.0757,-107.56299999999999
-SK514,McTaggart,,Saskatchewan,CA,49.7303,-104.01100000000001
+SK512,McLean,,Saskatchewan,CA,50.5167,-104.067
+SK513,McMahon,,Saskatchewan,CA,50.0757,-107.563
+SK514,McTaggart,,Saskatchewan,CA,49.7303,-104.011
 SK515,Meacham,,Saskatchewan,CA,52.1075,-105.76
 SK516,Meadow Lake,,Saskatchewan,CA,54.1266,-108.434
 SK517,Meath Park,,Saskatchewan,CA,53.4425,-105.369
@@ -532,11 +532,11 @@ SK530,Middle Lake,,Saskatchewan,CA,52.4813,-105.305
 SK531,Mikado,,Saskatchewan,CA,51.6088,-102.27
 SK532,Milden,,Saskatchewan,CA,51.4873,-107.52
 SK533,Mildred,,Saskatchewan,CA,53.35,-107.333
-SK534,Milestone,,Saskatchewan,CA,49.9931,-104.51700000000001
+SK534,Milestone,,Saskatchewan,CA,49.9931,-104.517
 SK535,Ministik Beach,,Saskatchewan,CA,51.6378,-101.625
-SK536,Minowukaw Beach,,Saskatchewan,CA,53.778999999999996,-105.16
+SK536,Minowukaw Beach,,Saskatchewan,CA,53.779,-105.16
 SK537,Minton,,Saskatchewan,CA,49.165,-104.583
-SK538,Missinipe,,Saskatchewan,CA,55.6,-104.76700000000001
+SK538,Missinipe,,Saskatchewan,CA,55.6,-104.767
 SK539,Mistatim,,Saskatchewan,CA,52.8719,-103.359
 SK540,Mistawasis,,Saskatchewan,CA,53.1833,-106.8
 SK541,Mistusinne,,Saskatchewan,CA,51.0635,-106.521
@@ -545,70 +545,70 @@ SK543,Mont Nebo,,Saskatchewan,CA,53.2833,-106.85
 SK544,Montmartre,,Saskatchewan,CA,50.2197,-103.45
 SK545,Montreal Lake,,Saskatchewan,CA,54.0456,-105.773
 SK546,Moose Bay,,Saskatchewan,CA,50.6132,-102.685
-SK547,Moose Jaw,,Saskatchewan,CA,50.4,-105.53299999999999
+SK547,Moose Jaw,,Saskatchewan,CA,50.4,-105.533
 SK548,Moose Range,,Saskatchewan,CA,53.2333,-103.7
-SK549,Moosomin,,Saskatchewan,CA,50.141999999999996,-101.67
+SK549,Moosomin,,Saskatchewan,CA,50.142,-101.67
 SK550,Moosomin,,Saskatchewan,CA,50.1444,-101.667
 SK551,Morse,,Saskatchewan,CA,50.4159,-107.04
 SK552,Mortlach,,Saskatchewan,CA,50.4547,-106.068
 SK553,Mosquito-Grizzly Bear's Head-Lean Man,,Saskatchewan,CA,52.4905,-108.211
-SK554,Mossbank,,Saskatchewan,CA,49.9392,-105.96600000000001
+SK554,Mossbank,,Saskatchewan,CA,49.9392,-105.966
 SK555,Mozart,,Saskatchewan,CA,51.7756,-103.994
-SK556,Muenster,,Saskatchewan,CA,52.191,-104.99700000000001
+SK556,Muenster,,Saskatchewan,CA,52.191,-104.997
 SK557,Mullingar,,Saskatchewan,CA,53.0848,-107.663
 SK558,Murray Point,,Saskatchewan,CA,53.607,-105.927
 SK559,Muscowpetung,,Saskatchewan,CA,50.7793,-104.285
 SK560,Muskoday,,Saskatchewan,CA,53.0943,-105.484
 SK561,Muskowekwan,,Saskatchewan,CA,51.3225,-104.0
-SK562,Naicam,,Saskatchewan,CA,52.4176,-104.49600000000001
+SK562,Naicam,,Saskatchewan,CA,52.4176,-104.496
 SK563,Neilburg,,Saskatchewan,CA,52.8387,-109.624
 SK564,Nekaneet,,Saskatchewan,CA,49.7657,-109.277
 SK565,Nesslin Lake,,Saskatchewan,CA,53.93,-106.786
-SK566,Netherhill,,Saskatchewan,CA,51.4701,-108.85600000000001
+SK566,Netherhill,,Saskatchewan,CA,51.4701,-108.856
 SK567,Neuanlage,,Saskatchewan,CA,52.4532,-106.463
-SK568,Neudorf,,Saskatchewan,CA,50.711999999999996,-103.015
-SK569,Neuhorst,,Saskatchewan,CA,52.4009,-106.57700000000001
+SK568,Neudorf,,Saskatchewan,CA,50.712,-103.015
+SK569,Neuhorst,,Saskatchewan,CA,52.4009,-106.577
 SK570,Neville,,Saskatchewan,CA,49.9667,-107.633
 SK571,Nipawin,,Saskatchewan,CA,53.3613,-104.014
 SK572,Nokomis,,Saskatchewan,CA,51.5086,-105.01
 SK573,Norquay,,Saskatchewan,CA,51.8833,-102.083
 SK574,North Battleford,,Saskatchewan,CA,52.7782,-108.292
 SK575,North Colesdale Park,,Saskatchewan,CA,50.9579,-105.15
-SK576,North Grove,,Saskatchewan,CA,50.6969,-105.56299999999999
-SK577,North Portal,,Saskatchewan,CA,49.0046,-102.54899999999999
+SK576,North Grove,,Saskatchewan,CA,50.6969,-105.563
+SK577,North Portal,,Saskatchewan,CA,49.0046,-102.549
 SK578,North Shore Fishing Lake,,Saskatchewan,CA,51.8487,-103.515
-SK579,North Weyburn,,Saskatchewan,CA,49.6922,-103.80799999999999
-SK580,Northminster,,Saskatchewan,CA,53.3667,-109.93299999999999
+SK579,North Weyburn,,Saskatchewan,CA,49.6922,-103.808
+SK580,Northminster,,Saskatchewan,CA,53.3667,-109.933
 SK581,Northside,,Saskatchewan,CA,53.5115,-105.766
 SK582,Nut Mountain,,Saskatchewan,CA,52.1271,-103.38
 SK583,Oakshela,,Saskatchewan,CA,50.3946,-102.762
-SK584,Ocean Man,,Saskatchewan,CA,49.851000000000006,-103.021
-SK585,Ochapowace,,Saskatchewan,CA,50.475,-102.39200000000001
-SK586,Odessa,,Saskatchewan,CA,50.2833,-103.78299999999999
+SK584,Ocean Man,,Saskatchewan,CA,49.851,-103.021
+SK585,Ochapowace,,Saskatchewan,CA,50.475,-102.392
+SK586,Odessa,,Saskatchewan,CA,50.2833,-103.783
 SK587,Ogema,,Saskatchewan,CA,49.5747,-104.915
 SK588,Okanese,,Saskatchewan,CA,50.925,-103.384
-SK589,Okla,,Saskatchewan,CA,52.0117022,-103.1183436
+SK589,Okla,,Saskatchewan,CA,52.0117,-103.1183
 SK590,One Arrow 95,,Saskatchewan,CA,52.7348,-106.029
 SK591,Onion Lake,,Saskatchewan,CA,53.7082,-109.958
 SK592,Orcadia,,Saskatchewan,CA,51.2764,-102.613
 SK593,Orkney,,Saskatchewan,CA,49.1438,-107.911
-SK594,Ormiston,,Saskatchewan,CA,49.7385,-105.39299999999999
+SK594,Ormiston,,Saskatchewan,CA,49.7385,-105.393
 SK595,Osage,,Saskatchewan,CA,49.9568,-103.579
 SK596,Osler,,Saskatchewan,CA,52.3679,-106.537
 SK597,Otthon,,Saskatchewan,CA,51.0979,-102.598
-SK598,Ottman - Murray Beach,,Saskatchewan,CA,51.818000000000005,-103.47200000000001
-SK599,Oungre,,Saskatchewan,CA,49.1458,-103.79899999999999
-SK600,Outlook,,Saskatchewan,CA,51.4891,-107.06200000000001
+SK598,Ottman - Murray Beach,,Saskatchewan,CA,51.818,-103.472
+SK599,Oungre,,Saskatchewan,CA,49.1458,-103.799
+SK600,Outlook,,Saskatchewan,CA,51.4891,-107.062
 SK601,Outram,,Saskatchewan,CA,49.1449,-103.324
-SK602,Oxbow,,Saskatchewan,CA,49.2305,-102.17200000000001
+SK602,Oxbow,,Saskatchewan,CA,49.2305,-102.172
 SK603,Paddockwood,,Saskatchewan,CA,53.5078,-105.561
-SK604,Pakwaw Lake,,Saskatchewan,CA,53.4773,-102.65299999999999
+SK604,Pakwaw Lake,,Saskatchewan,CA,53.4773,-102.653
 SK605,Palmer,,Saskatchewan,CA,49.8599,-106.354
 SK606,Palo,,Saskatchewan,CA,52.1667,-108.3
 SK607,Pambrun,,Saskatchewan,CA,49.9333,-107.45
 SK608,Pangman,,Saskatchewan,CA,49.6465,-104.662
 SK609,Paradise Hill,,Saskatchewan,CA,53.5378,-109.458
-SK610,Parkbeg,,Saskatchewan,CA,50.45399999999999,-106.26899999999999
+SK610,Parkbeg,,Saskatchewan,CA,50.454,-106.269
 SK611,Parkland Beach,,Saskatchewan,CA,53.5514,-108.694
 SK612,Parkside,,Saskatchewan,CA,53.1656,-106.536
 SK613,Parkview,,Saskatchewan,CA,50.6172,-105.458
@@ -625,34 +625,34 @@ SK623,Peepeekisis,,Saskatchewan,CA,50.8693,-103.329
 SK624,Peerless,,Saskatchewan,CA,54.3474,-109.23
 SK625,Peesane,,Saskatchewan,CA,52.8682,-103.6
 SK626,Pelican Cove,,Saskatchewan,CA,53.1668,-107.054
-SK627,Pelican Lake 191C,,Saskatchewan,CA,53.7251,-107.73899999999999
-SK628,Pelican Narrows,,Saskatchewan,CA,55.1667,-102.93299999999999
+SK627,Pelican Lake 191C,,Saskatchewan,CA,53.7251,-107.739
+SK628,Pelican Narrows,,Saskatchewan,CA,55.1667,-102.933
 SK629,Pelican Point,,Saskatchewan,CA,53.0506,-108.318
 SK630,Pelican Pointe,,Saskatchewan,CA,50.8038,-105.031
 SK631,Pelly,,Saskatchewan,CA,51.8562,-101.929
-SK632,Pemmican Portage,,Saskatchewan,CA,53.9333,-102.28299999999999
-SK633,Pennant,,Saskatchewan,CA,50.5333,-108.23299999999999
-SK634,Pense,,Saskatchewan,CA,50.4167,-104.98299999999999
+SK632,Pemmican Portage,,Saskatchewan,CA,53.9333,-102.283
+SK633,Pennant,,Saskatchewan,CA,50.5333,-108.233
+SK634,Pense,,Saskatchewan,CA,50.4167,-104.983
 SK635,Penzance,,Saskatchewan,CA,51.0591,-105.439
-SK636,Percival,,Saskatchewan,CA,50.3636,-102.40899999999999
+SK636,Percival,,Saskatchewan,CA,50.3636,-102.409
 SK637,Perdue,,Saskatchewan,CA,52.0544,-107.544
 SK638,Périgord,,Saskatchewan,CA,52.3474,-103.566
 SK639,Peter Ballantyne,,Saskatchewan,CA,55.175,-102.906
 SK640,Peterson,,Saskatchewan,CA,52.188,-105.681
 SK641,Phillips Grove,,Saskatchewan,CA,53.8697,-106.935
-SK642,Piapot,,Saskatchewan,CA,49.989,-109.12100000000001
-SK643,Pierceland,,Saskatchewan,CA,54.3393,-109.78200000000001
+SK642,Piapot,,Saskatchewan,CA,49.989,-109.121
+SK643,Pierceland,,Saskatchewan,CA,54.3393,-109.782
 SK644,Pike Lake,,Saskatchewan,CA,51.9116,-106.818
-SK645,Pilger,,Saskatchewan,CA,52.4252,-105.26799999999999
+SK645,Pilger,,Saskatchewan,CA,52.4252,-105.268
 SK646,Pilot Butte,,Saskatchewan,CA,50.481,-104.42
 SK647,Pinehouse,,Saskatchewan,CA,55.5194,-106.574
 SK648,Pleasantdale,,Saskatchewan,CA,52.5779,-104.506
 SK649,Plenty,,Saskatchewan,CA,51.7829,-108.646
 SK650,Plunkett,,Saskatchewan,CA,51.9079,-105.445
-SK651,Ponteix,,Saskatchewan,CA,49.7458,-107.48899999999999
-SK652,Pontrilas,,Saskatchewan,CA,53.2167,-104.03299999999999
+SK651,Ponteix,,Saskatchewan,CA,49.7458,-107.489
+SK652,Pontrilas,,Saskatchewan,CA,53.2167,-104.033
 SK653,Porcupine Plain,,Saskatchewan,CA,52.5989,-103.255
-SK654,Poundmaker,,Saskatchewan,CA,52.8959,-108.97399999999999
+SK654,Poundmaker,,Saskatchewan,CA,52.8959,-108.974
 SK655,Powm Beach,,Saskatchewan,CA,53.5734,-108.704
 SK656,Prairie River,,Saskatchewan,CA,52.8618,-102.993
 SK657,Preeceville,,Saskatchewan,CA,51.9558,-102.666
@@ -662,39 +662,39 @@ SK660,Prince,,Saskatchewan,CA,52.9624,-108.367
 SK661,Prince Albert,,Saskatchewan,CA,53.1988,-105.765
 SK662,Prongua,,Saskatchewan,CA,52.7437,-108.546
 SK663,Prud'homme,,Saskatchewan,CA,52.3384,-105.89
-SK664,Punnichy,,Saskatchewan,CA,51.3714,-104.29700000000001
+SK664,Punnichy,,Saskatchewan,CA,51.3714,-104.297
 SK665,Qu'Appelle,,Saskatchewan,CA,50.5434,-103.876
-SK666,Quill Lake,,Saskatchewan,CA,52.0713,-104.25299999999999
-SK667,Quinton,,Saskatchewan,CA,51.38399999999999,-104.404
-SK668,Rabbit Lake,,Saskatchewan,CA,53.1449,-107.76700000000001
-SK669,Radisson,,Saskatchewan,CA,52.4615,-107.39200000000001
+SK666,Quill Lake,,Saskatchewan,CA,52.0713,-104.253
+SK667,Quinton,,Saskatchewan,CA,51.384,-104.404
+SK668,Rabbit Lake,,Saskatchewan,CA,53.1449,-107.767
+SK669,Radisson,,Saskatchewan,CA,52.4615,-107.392
 SK670,Radville,,Saskatchewan,CA,49.4613,-104.3
-SK671,Rama,,Saskatchewan,CA,51.7574,-103.00200000000001
-SK672,Ranger,,Saskatchewan,CA,53.6100853,-107.6979207
-SK673,Rapid View,,Saskatchewan,CA,54.15,-108.81700000000001
+SK671,Rama,,Saskatchewan,CA,51.7574,-103.002
+SK672,Ranger,,Saskatchewan,CA,53.6101,-107.6979
+SK673,Rapid View,,Saskatchewan,CA,54.15,-108.817
 SK674,Raymore,,Saskatchewan,CA,51.4098,-104.527
 SK675,Red Deer Hill,,Saskatchewan,CA,53.0226,-105.805
-SK676,Red Earth,,Saskatchewan,CA,53.4861,-102.86200000000001
+SK676,Red Earth,,Saskatchewan,CA,53.4861,-102.862
 SK677,Red Jacket,,Saskatchewan,CA,50.2101,-101.79
 SK678,Red Pheasant,,Saskatchewan,CA,52.4606,-108.17
 SK679,Redvers,,Saskatchewan,CA,49.5733,-101.698
 SK680,Regina,,Saskatchewan,CA,50.45,-104.617
-SK681,Regina Beach,,Saskatchewan,CA,50.7905,-104.98100000000001
+SK681,Regina Beach,,Saskatchewan,CA,50.7905,-104.981
 SK682,Renown,,Saskatchewan,CA,51.6333,-105.55
-SK683,Reserve,,Saskatchewan,CA,52.4701,-102.64399999999999
-SK684,Rex,,Saskatchewan,CA,53.45,-109.93299999999999
+SK683,Reserve,,Saskatchewan,CA,52.4701,-102.644
+SK684,Rex,,Saskatchewan,CA,53.45,-109.933
 SK685,Rhein,,Saskatchewan,CA,51.3528,-102.19
-SK686,Rheinfeld,,Saskatchewan,CA,50.1167,-107.56700000000001
+SK686,Rheinfeld,,Saskatchewan,CA,50.1167,-107.567
 SK687,Rheinland,,Saskatchewan,CA,52.4174,-106.505
 SK688,Riceton,,Saskatchewan,CA,50.1112,-104.319
-SK689,Richard,,Saskatchewan,CA,52.6929,-107.70299999999999
+SK689,Richard,,Saskatchewan,CA,52.6929,-107.703
 SK690,Richardson,,Saskatchewan,CA,50.3833,-104.45
 SK691,Richmound,,Saskatchewan,CA,50.4547,-109.756
 SK692,Ridgedale,,Saskatchewan,CA,53.0563,-104.152
 SK693,Riverhurst,,Saskatchewan,CA,50.9025,-106.867
 SK694,Riversedge,,Saskatchewan,CA,52.2222,-106.553
-SK695,Riverside Estates,,Saskatchewan,CA,52.0473,-106.70100000000001
-SK696,Robsart,,Saskatchewan,CA,49.3833,-109.28299999999999
+SK695,Riverside Estates,,Saskatchewan,CA,52.0473,-106.701
+SK696,Robsart,,Saskatchewan,CA,49.3833,-109.283
 SK697,Rocanville,,Saskatchewan,CA,50.3833,-101.7
 SK698,Roche Percee,,Saskatchewan,CA,49.0667,-102.8
 SK699,Rockglen,,Saskatchewan,CA,49.1833,-105.95
@@ -706,11 +706,11 @@ SK704,Rosetown,,Saskatchewan,CA,51.5571,-107.984
 SK705,Rosthern,,Saskatchewan,CA,52.6667,-106.333
 SK706,Rouleau,,Saskatchewan,CA,50.1898,-104.902
 SK707,Ruby Beach,,Saskatchewan,CA,52.9665,-102.348
-SK708,Ruddell,,Saskatchewan,CA,52.6051,-107.85799999999999
-SK709,Runnymede,,Saskatchewan,CA,51.4791,-101.70100000000001
+SK708,Ruddell,,Saskatchewan,CA,52.6051,-107.858
+SK709,Runnymede,,Saskatchewan,CA,51.4791,-101.701
 SK710,Rush Lake,,Saskatchewan,CA,50.4052,-107.399
-SK711,Ruthilda,,Saskatchewan,CA,51.8921,-108.46600000000001
-SK712,Sakimay,,Saskatchewan,CA,50.5273,-102.79299999999999
+SK711,Ruthilda,,Saskatchewan,CA,51.8921,-108.466
+SK712,Sakimay,,Saskatchewan,CA,50.5273,-102.793
 SK713,Saltcoats,,Saskatchewan,CA,51.0431,-102.163
 SK714,Salvador,,Saskatchewan,CA,52.1681,-109.509
 SK715,Sand Point Beach,,Saskatchewan,CA,50.6944,-105.581
@@ -718,130 +718,130 @@ SK716,Sandy Bay,,Saskatchewan,CA,55.5227,-102.303
 SK717,Sandy Beach,,Saskatchewan,CA,50.7225,-103.655
 SK718,Sarnia Beach,,Saskatchewan,CA,50.9955,-105.225
 SK719,Saskatchewan Beach,,Saskatchewan,CA,50.7955,-104.927
-SK720,Saskatoon,,Saskatchewan,CA,52.1307,-106.65899999999999
+SK720,Saskatoon,,Saskatchewan,CA,52.1307,-106.659
 SK721,Saulteaux 159,,Saskatchewan,CA,53.1227,-108.337
-SK722,Sceptre,,Saskatchewan,CA,50.8622,-109.26700000000001
+SK722,Sceptre,,Saskatchewan,CA,50.8622,-109.267
 SK723,Schoenfeld,,Saskatchewan,CA,50.0889,-107.699
 SK724,Scott,,Saskatchewan,CA,52.3667,-108.833
 SK725,Scout Lake,,Saskatchewan,CA,49.3646,-106.0
 SK726,Sedley,,Saskatchewan,CA,50.1686,-104.014
 SK727,Semans,,Saskatchewan,CA,51.4064,-104.729
-SK728,Senlac,,Saskatchewan,CA,52.4918,-109.70700000000001
+SK728,Senlac,,Saskatchewan,CA,52.4918,-109.707
 SK729,Shackleton,,Saskatchewan,CA,50.6849,-108.605
 SK730,Shamrock,,Saskatchewan,CA,50.1607,-106.624
 SK731,Shaunavon,,Saskatchewan,CA,49.65,-108.417
 SK732,Sheho,,Saskatchewan,CA,51.5883,-103.214
-SK733,Shell Lake,,Saskatchewan,CA,53.3062,-107.06299999999999
+SK733,Shell Lake,,Saskatchewan,CA,53.3062,-107.063
 SK734,Shellbrook,,Saskatchewan,CA,53.2232,-106.385
-SK735,Shields,,Saskatchewan,CA,51.8214,-106.41799999999999
-SK736,Shipman,,Saskatchewan,CA,53.4758,-104.98200000000001
+SK735,Shields,,Saskatchewan,CA,51.8214,-106.418
+SK736,Shipman,,Saskatchewan,CA,53.4758,-104.982
 SK737,Silton,,Saskatchewan,CA,50.8075,-104.91
 SK738,Silver Park,,Saskatchewan,CA,52.665,-104.523
-SK739,Simmie,,Saskatchewan,CA,49.943999999999996,-108.105
+SK739,Simmie,,Saskatchewan,CA,49.944,-108.105
 SK740,Simpson,,Saskatchewan,CA,51.4486,-105.444
 SK741,Sintaluta,,Saskatchewan,CA,50.479,-103.449
-SK742,Sled Lake,,Saskatchewan,CA,54.428000000000004,-107.321
+SK742,Sled Lake,,Saskatchewan,CA,54.428,-107.321
 SK743,Sleepy Hollow,,Saskatchewan,CA,53.0631,-108.321
 SK744,Smeaton,,Saskatchewan,CA,53.4923,-104.806
 SK745,Smiley,,Saskatchewan,CA,51.6319,-109.47
 SK746,Smoky Burn,,Saskatchewan,CA,53.3667,-103.133
 SK747,Snowden,,Saskatchewan,CA,53.4916,-104.678
-SK748,Sonningdale,,Saskatchewan,CA,52.3833,-107.68299999999999
+SK748,Sonningdale,,Saskatchewan,CA,52.3833,-107.683
 SK749,Sorenson's Beach,,Saskatchewan,CA,50.8364,-105.057
-SK750,South Lake,,Saskatchewan,CA,50.6763,-105.56299999999999
-SK751,Southend Reindeer,,Saskatchewan,CA,56.3266,-103.23899999999999
+SK750,South Lake,,Saskatchewan,CA,50.6763,-105.563
+SK751,Southend Reindeer,,Saskatchewan,CA,56.3266,-103.239
 SK752,Southey,,Saskatchewan,CA,50.9401,-104.499
-SK753,Sovereign,,Saskatchewan,CA,51.5167,-107.71700000000001
+SK753,Sovereign,,Saskatchewan,CA,51.5167,-107.717
 SK754,Spalding,,Saskatchewan,CA,52.3288,-104.495
-SK755,Speers,,Saskatchewan,CA,52.7083,-107.55799999999999
-SK756,Spiritwood,,Saskatchewan,CA,53.364,-107.51899999999999
-SK757,Spring Bay,,Saskatchewan,CA,50.9361,-105.13600000000001
-SK758,Spring Valley,,Saskatchewan,CA,49.9432,-105.40299999999999
+SK755,Speers,,Saskatchewan,CA,52.7083,-107.558
+SK756,Spiritwood,,Saskatchewan,CA,53.364,-107.519
+SK757,Spring Bay,,Saskatchewan,CA,50.9361,-105.136
+SK758,Spring Valley,,Saskatchewan,CA,49.9432,-105.403
 SK759,Springfeld,,Saskatchewan,CA,50.1419,-107.734
 SK760,Springside,,Saskatchewan,CA,51.345,-102.742
 SK761,Springside,,Saskatchewan,CA,51.3465,-102.743
-SK762,Springwater,,Saskatchewan,CA,51.9727,-108.37799999999999
-SK763,Spruce Bay,,Saskatchewan,CA,53.2069,-107.69200000000001
-SK764,Spruce Home,,Saskatchewan,CA,53.3941,-105.76700000000001
+SK762,Springwater,,Saskatchewan,CA,51.9727,-108.378
+SK763,Spruce Bay,,Saskatchewan,CA,53.2069,-107.692
+SK764,Spruce Home,,Saskatchewan,CA,53.3941,-105.767
 SK765,Spruce Lake,,Saskatchewan,CA,53.5425,-109.088
 SK766,Spy Hill,,Saskatchewan,CA,50.6022,-101.685
-SK767,St. Benedict,,Saskatchewan,CA,52.5683,-105.39399999999999
-SK768,St. Brieux,,Saskatchewan,CA,52.6356,-104.89200000000001
-SK769,St. Cyr Lake,,Saskatchewan,CA,54.2167,-108.06700000000001
+SK767,St. Benedict,,Saskatchewan,CA,52.5683,-105.394
+SK768,St. Brieux,,Saskatchewan,CA,52.6356,-104.892
+SK769,St. Cyr Lake,,Saskatchewan,CA,54.2167,-108.067
 SK770,St. George's Hill,,Saskatchewan,CA,55.8769,-108.961
-SK771,St. Gregor,,Saskatchewan,CA,52.1776,-104.82700000000001
-SK772,St. Isidore-de-Bellevue,,Saskatchewan,CA,52.7843,-105.92200000000001
+SK771,St. Gregor,,Saskatchewan,CA,52.1776,-104.827
+SK772,St. Isidore-de-Bellevue,,Saskatchewan,CA,52.7843,-105.922
 SK773,St. Joseph's,,Saskatchewan,CA,50.4966,-104.18
-SK774,St. Louis,,Saskatchewan,CA,52.9152,-105.81200000000001
+SK774,St. Louis,,Saskatchewan,CA,52.9152,-105.812
 SK775,St. Walburg,,Saskatchewan,CA,53.6326,-109.198
-SK776,Stalwart,,Saskatchewan,CA,51.2339,-105.44200000000001
+SK776,Stalwart,,Saskatchewan,CA,51.2339,-105.442
 SK777,Stanley Mission,,Saskatchewan,CA,55.4147,-104.566
-SK778,Star Blanket 83,,Saskatchewan,CA,50.9615786,-103.5139042
-SK779,Star City,,Saskatchewan,CA,52.8625,-104.33200000000001
+SK778,Star Blanket 83,,Saskatchewan,CA,50.9616,-103.5139
+SK779,Star City,,Saskatchewan,CA,52.8625,-104.332
 SK780,Starblanket,,Saskatchewan,CA,53.3683,-106.913
-SK781,Steen,,Saskatchewan,CA,52.6805,-103.52600000000001
+SK781,Steen,,Saskatchewan,CA,52.6805,-103.526
 SK782,Stenen,,Saskatchewan,CA,51.9002,-102.38
 SK783,Stewart Valley,,Saskatchewan,CA,50.5978,-107.805
 SK784,Stockholm,,Saskatchewan,CA,50.661,-102.302
 SK785,Stony Beach,,Saskatchewan,CA,50.4715,-105.163
 SK786,Stony Rapids,,Saskatchewan,CA,59.254,-105.837
-SK787,Stornoway,,Saskatchewan,CA,51.2944,-102.03399999999999
+SK787,Stornoway,,Saskatchewan,CA,51.2944,-102.034
 SK788,Storthoaks,,Saskatchewan,CA,49.3894,-101.601
 SK789,Stoughton,,Saskatchewan,CA,49.6797,-103.027
 SK790,Stranraer,,Saskatchewan,CA,51.7082,-108.485
 SK791,Strasbourg,,Saskatchewan,CA,51.0708,-104.958
 SK792,Strongfield,,Saskatchewan,CA,51.3338,-106.596
 SK793,Sturgeon Lake,,Saskatchewan,CA,53.4101,-105.991
-SK794,Sturgeon Landing,,Saskatchewan,CA,54.2698,-101.82700000000001
-SK795,Sturgis,,Saskatchewan,CA,51.9371,-102.53299999999999
+SK794,Sturgeon Landing,,Saskatchewan,CA,54.2698,-101.827
+SK795,Sturgis,,Saskatchewan,CA,51.9371,-102.533
 SK796,Success,,Saskatchewan,CA,50.4596,-108.079
 SK797,Summerberry,,Saskatchewan,CA,50.4167,-103.1
-SK798,Summerfield Beach,,Saskatchewan,CA,53.0401,-108.30799999999999
+SK798,Summerfield Beach,,Saskatchewan,CA,53.0401,-108.308
 SK799,Sun Valley,,Saskatchewan,CA,50.6544,-105.53
 SK800,Sunset Beach,,Saskatchewan,CA,50.6021,-102.666
-SK801,Sunset Cove,,Saskatchewan,CA,50.8111,-105.00299999999999
-SK802,Sunset View Beach,,Saskatchewan,CA,53.5491,-108.62299999999999
+SK801,Sunset Cove,,Saskatchewan,CA,50.8111,-105.003
+SK802,Sunset View Beach,,Saskatchewan,CA,53.5491,-108.623
 SK803,Swan Plain,,Saskatchewan,CA,52.115,-102.054
 SK804,Swanson,,Saskatchewan,CA,51.7,-107.15
 SK805,Sweetgrass,,Saskatchewan,CA,52.7626,-108.713
 SK806,Swift Current,,Saskatchewan,CA,50.2844,-107.791
-SK807,Sylvania,,Saskatchewan,CA,52.6941,-104.00299999999999
+SK807,Sylvania,,Saskatchewan,CA,52.6941,-104.003
 SK808,Tadmore,,Saskatchewan,CA,51.8341,-102.479
 SK809,Tangleflags,,Saskatchewan,CA,53.4833,-109.633
-SK810,Tantallon,,Saskatchewan,CA,50.5349,-101.84100000000001
+SK810,Tantallon,,Saskatchewan,CA,50.5349,-101.841
 SK811,Taylor Beach,,Saskatchewan,CA,50.6907,-103.654
 SK812,Tessier,,Saskatchewan,CA,51.8078,-107.429
 SK813,The Key 65,,Saskatchewan,CA,51.7829,-102.115
 SK814,Theodore,,Saskatchewan,CA,51.4257,-102.921
-SK815,Thode,,Saskatchewan,CA,51.7881,-106.44200000000001
+SK815,Thode,,Saskatchewan,CA,51.7881,-106.442
 SK816,Thunderchild,,Saskatchewan,CA,53.4576,-108.87
 SK817,Timber Bay,,Saskatchewan,CA,54.1583,-105.678
 SK818,Tisdale,,Saskatchewan,CA,52.85,-104.05
-SK819,Tobin Lake,,Saskatchewan,CA,53.5167,-103.73299999999999
-SK820,Togo,,Saskatchewan,CA,51.4025,-101.58200000000001
-SK821,Tompkins,,Saskatchewan,CA,50.0626,-108.79700000000001
+SK819,Tobin Lake,,Saskatchewan,CA,53.5167,-103.733
+SK820,Togo,,Saskatchewan,CA,51.4025,-101.582
+SK821,Tompkins,,Saskatchewan,CA,50.0626,-108.797
 SK822,Torquay,,Saskatchewan,CA,49.1409,-103.491
 SK823,Tramping Lake,,Saskatchewan,CA,52.1333,-108.95
 SK824,Tregarva,,Saskatchewan,CA,50.6034,-104.709
 SK825,Tribune,,Saskatchewan,CA,49.2484,-103.824
-SK826,Trossachs,,Saskatchewan,CA,49.6371,-104.22399999999999
-SK827,Truax,,Saskatchewan,CA,49.903999999999996,-104.946
-SK828,Tuffnell,,Saskatchewan,CA,51.6421,-103.37100000000001
+SK826,Trossachs,,Saskatchewan,CA,49.6371,-104.224
+SK827,Truax,,Saskatchewan,CA,49.904,-104.946
+SK828,Tuffnell,,Saskatchewan,CA,51.6421,-103.371
 SK829,Tugaske,,Saskatchewan,CA,50.8737,-106.287
 SK830,Turnor Lake,,Saskatchewan,CA,56.4601,-108.72
 SK831,Turtle Lake South Bay,,Saskatchewan,CA,53.5122,-108.705
 SK832,Turtleford,,Saskatchewan,CA,53.3887,-108.958
 SK833,Tuxford,,Saskatchewan,CA,50.5761,-105.58
 SK834,Tway,,Saskatchewan,CA,52.7376,-105.439
-SK835,Tyvan,,Saskatchewan,CA,50.0334,-103.71799999999999
+SK835,Tyvan,,Saskatchewan,CA,50.0334,-103.718
 SK836,Uhl's Bay,,Saskatchewan,CA,50.9843,-105.141
-SK837,Unity,,Saskatchewan,CA,52.4398,-109.15799999999999
+SK837,Unity,,Saskatchewan,CA,52.4398,-109.158
 SK838,Uranium City,,Saskatchewan,CA,59.5667,-108.617
-SK839,Usherville,,Saskatchewan,CA,52.2314,-102.65700000000001
+SK839,Usherville,,Saskatchewan,CA,52.2314,-102.657
 SK840,Val Marie,,Saskatchewan,CA,49.2457,-107.728
 SK841,Valparaiso,,Saskatchewan,CA,52.8513,-104.186
-SK842,Vanguard,,Saskatchewan,CA,49.9059,-107.29899999999999
-SK843,Vanscoy,,Saskatchewan,CA,52.0019,-106.97399999999999
+SK842,Vanguard,,Saskatchewan,CA,49.9059,-107.299
+SK843,Vanscoy,,Saskatchewan,CA,52.0019,-106.974
 SK844,Vanstone,,Saskatchewan,CA,51.2111,-102.617
 SK845,Vantage,,Saskatchewan,CA,49.8424,-106.031
 SK846,Vawn,,Saskatchewan,CA,53.106,-108.664
@@ -851,14 +851,14 @@ SK849,Vibank,,Saskatchewan,CA,50.3354,-103.947
 SK850,Viscount,,Saskatchewan,CA,51.9464,-105.648
 SK851,Vonda,,Saskatchewan,CA,52.3236,-106.096
 SK852,Wadena,,Saskatchewan,CA,51.9471,-103.796
-SK853,Wahpeton Dakota,,Saskatchewan,CA,53.2742,-105.90299999999999
+SK853,Wahpeton Dakota,,Saskatchewan,CA,53.2742,-105.903
 SK854,Wakaw,,Saskatchewan,CA,52.6489,-105.74
-SK855,Wakaw Lake,,Saskatchewan,CA,52.6364,-105.64399999999999
-SK856,Waldeck,,Saskatchewan,CA,50.358999999999995,-107.595
-SK857,Waldheim,,Saskatchewan,CA,52.6188,-106.65299999999999
+SK855,Wakaw Lake,,Saskatchewan,CA,52.6364,-105.644
+SK856,Waldeck,,Saskatchewan,CA,50.359,-107.595
+SK857,Waldheim,,Saskatchewan,CA,52.6188,-106.653
 SK858,Waldron,,Saskatchewan,CA,50.8519,-102.515
 SK859,Wapella,,Saskatchewan,CA,50.2615,-101.97
-SK860,Warman,,Saskatchewan,CA,52.3186,-106.57799999999999
+SK860,Warman,,Saskatchewan,CA,52.3186,-106.578
 SK861,Wartime,,Saskatchewan,CA,51.2136,-108.193
 SK862,Waseca,,Saskatchewan,CA,53.1002,-109.471
 SK863,Waskesiu Lake,,Saskatchewan,CA,53.92,-106.079
@@ -869,42 +869,42 @@ SK867,Wauchope,,Saskatchewan,CA,49.5964,-101.904
 SK868,Wawota,,Saskatchewan,CA,49.9057,-102.023
 SK869,Webb,,Saskatchewan,CA,50.1833,-108.2
 SK870,Wee Too Beach,,Saskatchewan,CA,50.9354,-105.17
-SK871,Weekes,,Saskatchewan,CA,52.5697,-102.87100000000001
+SK871,Weekes,,Saskatchewan,CA,52.5697,-102.871
 SK872,Weirdale,,Saskatchewan,CA,53.4475,-105.238
-SK873,Weldon,,Saskatchewan,CA,53.0088,-105.14299999999999
+SK873,Weldon,,Saskatchewan,CA,53.0088,-105.143
 SK874,Welwyn,,Saskatchewan,CA,50.325,-101.515
 SK875,West End,,Saskatchewan,CA,50.5492,-102.415
-SK876,Westview,,Saskatchewan,CA,50.9309,-102.85799999999999
+SK876,Westview,,Saskatchewan,CA,50.9309,-102.858
 SK877,Weyakwin,,Saskatchewan,CA,54.4314,-105.803
 SK878,Weyburn,,Saskatchewan,CA,49.6667,-103.85
 SK879,White Bear,,Saskatchewan,CA,50.8796,-108.219
 SK880,White City,,Saskatchewan,CA,50.4409,-104.368
 SK881,White Fox,,Saskatchewan,CA,53.45,-104.083
 SK882,Whitebeech,,Saskatchewan,CA,52.0558,-101.704
-SK883,Whitecap,,Saskatchewan,CA,51.8731,-106.70100000000001
-SK884,Whitewood,,Saskatchewan,CA,50.3333,-102.26700000000001
-SK885,Wilcox,,Saskatchewan,CA,50.0982,-104.72200000000001
+SK883,Whitecap,,Saskatchewan,CA,51.8731,-106.701
+SK884,Whitewood,,Saskatchewan,CA,50.3333,-102.267
+SK885,Wilcox,,Saskatchewan,CA,50.0982,-104.722
 SK886,Wilkie,,Saskatchewan,CA,52.4082,-108.706
 SK887,Willmar,,Saskatchewan,CA,49.4816,-102.476
 SK888,Willow Bunch,,Saskatchewan,CA,49.3922,-105.633
-SK889,Willowbrook,,Saskatchewan,CA,51.2047,-102.79700000000001
+SK889,Willowbrook,,Saskatchewan,CA,51.2047,-102.797
 SK890,Wimmer,,Saskatchewan,CA,52.095,-104.399
 SK891,Windthorst,,Saskatchewan,CA,50.1085,-102.836
 SK892,Wiseton,,Saskatchewan,CA,51.3137,-107.649
-SK893,Wishart,,Saskatchewan,CA,51.548,-103.98299999999999
+SK893,Wishart,,Saskatchewan,CA,51.548,-103.983
 SK894,Witchekan Lake,,Saskatchewan,CA,53.5005,-107.596
-SK895,Wollaston Lake,,Saskatchewan,CA,58.165251899999994,-103.7879148
+SK895,Wollaston Lake,,Saskatchewan,CA,58.1653,-103.7879
 SK896,Wolseley,,Saskatchewan,CA,50.4235,-103.272
 SK897,Wood Mountain,,Saskatchewan,CA,49.3709,-106.383
-SK898,Wroxton,,Saskatchewan,CA,51.2267,-101.88600000000001
+SK898,Wroxton,,Saskatchewan,CA,51.2267,-101.886
 SK899,Wymark,,Saskatchewan,CA,50.1101,-107.736
-SK900,Wynyard,,Saskatchewan,CA,51.7667,-104.18299999999999
-SK901,Yarbo,,Saskatchewan,CA,50.7,-101.93299999999999
+SK900,Wynyard,,Saskatchewan,CA,51.7667,-104.183
+SK901,Yarbo,,Saskatchewan,CA,50.7,-101.933
 SK902,Yellow Creek,,Saskatchewan,CA,52.75,-105.25
 SK903,Yellow Grass,,Saskatchewan,CA,49.8041,-104.161
 SK904,Yorkton,,Saskatchewan,CA,51.2098,-102.449
 SK905,Young,,Saskatchewan,CA,51.7677,-105.743
 SK906,Zealandia,,Saskatchewan,CA,51.6155,-107.743
 SK907,Zelma,,Saskatchewan,CA,51.8424,-105.905
-SK908,Zeneta,,Saskatchewan,CA,50.7333,-102.06700000000001
+SK908,Zeneta,,Saskatchewan,CA,50.7333,-102.067
 SK909,Zenon Park,,Saskatchewan,CA,53.0659,-103.756

--- a/vector_data/point/yukon_point_locations.csv
+++ b/vector_data/point/yukon_point_locations.csv
@@ -1,5 +1,5 @@
 id,name,alt_name,region,country,latitude,longitude
-YT1,Aishihik,,Yukon,CA,61.5986,-137.50799999999998
+YT1,Aishihik,,Yukon,CA,61.5986,-137.508
 YT2,Bear Creek,,Yukon,CA,60.7975,-137.67
 YT3,Bear Creek,,Yukon,CA,60.8023,-137.7001
 YT4,Beaver Creek,,Yukon,CA,62.3833,-140.875
@@ -9,16 +9,16 @@ YT7,Burwash Landing,,Yukon,CA,61.3542,-138.994
 YT8,Canyon City,,Yukon,CA,60.6344,-134.774
 YT9,Carcross,,Yukon,CA,60.1694,-134.701
 YT10,Carmacks,,Yukon,CA,62.0888,-136.284
-YT11,Champagne,,Yukon,CA,60.7889,-136.47899999999998
+YT11,Champagne,,Yukon,CA,60.7889,-136.479
 YT12,Conrad,,Yukon,CA,60.0691,-134.564
-YT13,Cowley,,Yukon,CA,60.5253,-134.89700000000002
+YT13,Cowley,,Yukon,CA,60.5253,-134.897
 YT14,Crestview,,Yukon,CA,60.8231,-135.204
 YT15,Dalton Post,,Yukon,CA,60.12,-137.025
 YT16,Dawson City,,Yukon,CA,64.0625,-139.431
-YT17,Destruction Bay,,Yukon,CA,61.2542,-138.80700000000002
+YT17,Destruction Bay,,Yukon,CA,61.2542,-138.807
 YT18,Dezadeash,,Yukon,CA,60.3722,-137.056
 YT19,Dry Creek,,Yukon,CA,62.1725,-140.6856
-YT20,Eagle Plains,,Yukon,CA,66.37100000000001,-136.72
+YT20,Eagle Plains,,Yukon,CA,66.371,-136.72
 YT21,Elsa,,Yukon,CA,63.9076,-135.476
 YT22,Faro,,Yukon,CA,62.2274,-133.35
 YT23,Fort Selkirk,,Yukon,CA,62.7723,-137.394
@@ -30,31 +30,31 @@ YT28,Ibex Valley,,Yukon,CA,60.8494,-135.639
 YT29,Jakes Corner,,Yukon,CA,60.3386,-133.984
 YT30,Johnsons Crossing,,Yukon,CA,60.4889,-133.297
 YT31,Keno City,,Yukon,CA,63.9083,-135.303
-YT32,Kloo Lake,,Yukon,CA,60.92100000000001,-137.857
+YT32,Kloo Lake,,Yukon,CA,60.921,-137.857
 YT33,Klukshu,,Yukon,CA,60.2945,-137.004
-YT34,Koidern,,Yukon,CA,61.9833,-140.49200000000002
+YT34,Koidern,,Yukon,CA,61.9833,-140.492
 YT35,Lewis,,Yukon,CA,60.333,-134.8328
 YT36,Little Gold Creek,,Yukon,CA,64.0861,-141.0
 YT37,Little River,,Yukon,CA,60.8787,-135.6908
 YT38,Little Salmon/Carmacks First Nation,,Yukon,CA,62.0561,-135.701
 YT39,Little Teslin Lake,,Yukon,CA,60.4819,-133.465
 YT40,Marsh Lake,,Yukon,CA,60.5193,-134.332
-YT41,Mayo,,Yukon,CA,63.5931,-135.89600000000002
+YT41,Mayo,,Yukon,CA,63.5931,-135.896
 YT42,McCabe Creek,,Yukon,CA,62.5284,-136.784
 YT43,Mendenhall Landing,,Yukon,CA,60.7528,-136.039
 YT44,Minto,,Yukon,CA,62.5848,-136.851
-YT45,Morley River,,Yukon,CA,60.013000000000005,-132.162
+YT45,Morley River,,Yukon,CA,60.013,-132.162
 YT46,Mount Lorne,,Yukon,CA,60.4126,-134.952
 YT47,Old Crow,,Yukon,CA,67.5729,-139.829
-YT48,Pelly Crossing,,Yukon,CA,62.8198,-136.57399999999998
+YT48,Pelly Crossing,,Yukon,CA,62.8198,-136.574
 YT49,Porter Creek,,Yukon,CA,60.7699,-135.136
 YT50,Quill Creek,,Yukon,CA,61.5079,-139.3306
 YT51,Rampart House,,Yukon,CA,67.4219,-140.993
-YT52,Rancheria,,Yukon,CA,60.0875,-130.60299999999998
+YT52,Rancheria,,Yukon,CA,60.0875,-130.603
 YT53,Riverdale,,Yukon,CA,60.7069,-135.024
 YT54,Robinson,,Yukon,CA,60.4512,-134.846
-YT55,Ross River,,Yukon,CA,61.9779,-132.44899999999998
-YT56,Snag,,Yukon,CA,62.4,-140.36700000000002
+YT55,Ross River,,Yukon,CA,61.9779,-132.449
+YT56,Snag,,Yukon,CA,62.4,-140.367
 YT57,Snag Junction,,Yukon,CA,62.2348,-140.692
 YT58,Stewart Crossing,,Yukon,CA,63.3675,-136.679
 YT59,Stewart River,Nä`chòo ndek,Yukon,CA,63.2917,-139.4117
@@ -62,16 +62,16 @@ YT60,Stony Creek Camp,,Yukon,CA,60.801,-135.976
 YT61,Swift River,,Yukon,CA,60.0042,-131.187
 YT62,Tagish,,Yukon,CA,60.31,-134.266
 YT63,Takhini,,Yukon,CA,60.8533,-135.447
-YT64,Ten Mile,,Yukon,CA,60.1667,-134.36700000000002
+YT64,Ten Mile,,Yukon,CA,60.1667,-134.367
 YT65,Teslin,ᑦᐁᔅᓕᓐᑦᐆ / Desleen,Yukon,CA,60.1683,-132.719
-YT66,Teslin Lake,,Yukon,CA,60.01667,-132.4333
+YT66,Teslin Lake,,Yukon,CA,60.0167,-132.4333
 YT67,Tuchitua,,Yukon,CA,60.9025,-129.2505
 YT68,Two and One-Half Mile Village,,Yukon,CA,60.1434,-128.881
 YT69,Two Mile Village,,Yukon,CA,60.1254,-128.804
 YT70,Upper Laberge,,Yukon,CA,60.9509,-135.132
 YT71,Upper Liard,,Yukon,CA,60.0545,-128.923
-YT72,Watson Lake,,Yukon,CA,60.0639,-128.70600000000002
-YT73,Whitehorse,,Yukon,CA,60.727,-135.07399999999998
+YT72,Watson Lake,,Yukon,CA,60.0639,-128.706
+YT73,Whitehorse,,Yukon,CA,60.727,-135.074
 YT74,Carcross Cutoff,,Yukon,CA,60.5958,-134.878
 YT75,Clinton Creek,,Yukon,CA,64.415,-140.602
-YT76,Nesketahin,Wesketahin,Yukon,CA,60.1334,-137.05700000000002
+YT76,Nesketahin,Wesketahin,Yukon,CA,60.1334,-137.057


### PR DESCRIPTION
This adds a field (column) `id` to each point location file that provides a unique alphanumeric key for the location. The format is the region postal code followed by an integer, e.g. `AK49` for the 49th located for Alaska.