### PR TITLE
Remove Fort Davis, AK

### DIFF
--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -129,7 +129,6 @@ AK125,False Pass,Isanax̂,Alaska,US,54.8548,-163.407
 AK126,Ferry,,Alaska,US,64.0172,-149.117
 AK127,Fish Village,,Alaska,US,62.5212,-163.847
 AK128,Flat,,Alaska,US,62.4536,-158.007
-AK437,Fort Davis,,Alaska,US,64.48,-165.42
 AK129,Fort Glenn,,Alaska,US,53.3956,-167.881
 AK440,Fort Greely,,Alaska,US,63.9731,-145.7181
 AK438,Fort Wainwright,,Alaska,US,64.8278,-147.6429


### PR DESCRIPTION
The SNAP team consensus was to remove this point location. The location has not been inhabited for nearly a century and it also is in very close proximity to Nome, AK. Removing this point will de-conflict that geographic space in tools that pull these locations. In particular, the double occupation of a single grid cell by Nome and Ft. Davis was creating some unexpected behavior in the sea ice atlas.

closes #3 