### PR TITLE
Deduplicate and disambiguate

### DIFF
--- a/vector_data/point/alberta_point_locations.csv
+++ b/vector_data/point/alberta_point_locations.csv
@@ -600,7 +600,6 @@ AB600,Sandy Lake,,Alberta,CA,55.8144,-113.416
 AB601,Sangudo,,Alberta,CA,53.8879,-114.895
 AB602,Saprae Creek,,Alberta,CA,56.6592,-111.143
 AB603,Saskatchewan River Crossing,,Alberta,CA,51.9758,-116.743
-AB604,Sawridge,,Alberta,CA,55.3117,-114.868
 AB605,Sawridge,,Alberta,CA,55.2901,-114.75
 AB606,Scandia,,Alberta,CA,50.2781,-112.047
 AB607,Schuler,,Alberta,CA,50.3407,-110.089

--- a/vector_data/point/alberta_point_locations.csv
+++ b/vector_data/point/alberta_point_locations.csv
@@ -45,7 +45,6 @@ AB43,Beaumont,,Alberta,CA,53.3525,-113.415
 AB44,Beauvallon,,Alberta,CA,53.6592,-111.362
 AB45,Beaver,,Alberta,CA,58.4708,-116.584
 AB46,Beaver Lake,,Alberta,CA,54.753,-111.927
-AB47,Beaver Lake,,Alberta,CA,54.6687,-111.907
 AB48,Beaver Mines,,Alberta,CA,49.4567,-114.197
 AB49,Beaverlodge,,Alberta,CA,55.2118,-119.422
 AB50,Beiseker,,Alberta,CA,51.385,-113.536
@@ -112,7 +111,6 @@ AB110,Cadotte Lake,,Alberta,CA,56.4705,-116.382
 AB111,Calahoo,,Alberta,CA,53.7145,-113.958
 AB112,Calgary,,Alberta,CA,51.0458,-114.057
 AB113,Calling Lake,,Alberta,CA,55.2103,-113.19
-AB114,Calling Lake,,Alberta,CA,55.2463,-113.198
 AB115,Calmar,,Alberta,CA,53.2664,-113.809
 AB116,Cambria,,Alberta,CA,51.3939,-112.59
 AB117,Campsie,,Alberta,CA,54.1278,-114.647
@@ -640,7 +638,6 @@ AB638,St. Isidore,,Alberta,CA,56.204,-117.107
 AB639,St. Lina,,Alberta,CA,54.2961,-111.454
 AB640,St. Michael,,Alberta,CA,53.8303,-112.636
 AB641,St. Paul,St-Paul-de-Métis,Alberta,CA,53.9913,-111.3269
-AB642,St. Paul,,Alberta,CA,53.9928,-111.296
 AB643,Stand Off,,Alberta,CA,49.4569,-113.303
 AB644,Standard,,Alberta,CA,51.1097,-112.984
 AB645,Stavely,,Alberta,CA,50.1611,-113.642
@@ -651,7 +648,6 @@ AB649,Stonelaw,,Alberta,CA,51.8686,-112.481
 AB650,Stony Plain,,Alberta,CA,53.5264,-114.007
 AB651,Strathmore,,Alberta,CA,51.0456,-113.393
 AB652,Strome,,Alberta,CA,52.8108,-112.067
-AB653,Sturgeon Lake,,Alberta,CA,55.1286,-117.476
 AB654,Sturgeon Lake,,Alberta,CA,55.0695,-117.489
 AB655,Suffield,,Alberta,CA,50.2183,-111.161
 AB656,Sunbreaker Cove,,Alberta,CA,52.3875,-114.187
@@ -669,7 +665,6 @@ AB667,Swalwell,,Alberta,CA,51.5572,-113.318
 AB668,Swan City Trailer Court,,Alberta,CA,55.1694,-118.754
 AB669,Swan Hills,,Alberta,CA,54.7167,-115.402
 AB670,Swan River,,Alberta,CA,55.3402,-115.451
-AB671,Sylvan Lake,,Alberta,CA,52.3047,-114.1145
 AB672,Sylvan Lake,,Alberta,CA,52.3057,-114.096
 AB673,T & E Trailer Park,,Alberta,CA,55.1766,-118.751
 AB674,Taber,,Alberta,CA,49.7848,-112.151
@@ -702,7 +697,6 @@ AB700,Val Quentin,,Alberta,CA,53.664,-114.385
 AB701,Valhalla Centre,,Alberta,CA,55.4036,-119.382
 AB702,Valleyview,,Alberta,CA,55.0659,-117.282
 AB703,Vauxhall,,Alberta,CA,50.0683,-112.107
-AB704,Vegreville,,Alberta,CA,53.4977,-112.1015
 AB705,Vegreville,,Alberta,CA,53.4956,-112.052
 AB706,Venice,,Alberta,CA,54.6978,-112.148
 AB707,Vermilion,,Alberta,CA,53.3547,-110.853

--- a/vector_data/point/british_columbia_point_locations.csv
+++ b/vector_data/point/british_columbia_point_locations.csv
@@ -109,7 +109,6 @@ BC111,Uchucklesaht,,British Columbia,CA,49.0274,-125.045
 BC112,Blueberry Creek,,British Columbia,CA,49.246,-117.659
 BC113,Criss Creek,,British Columbia,CA,51.05,-120.733
 BC114,Tl'etinqox,,British Columbia,CA,52.0119,-123.1719
-BC115,Kitselas,,British Columbia,CA,54.4872,-128.586
 BC116,Toquaht,,British Columbia,CA,48.9959,-125.379
 BC117,Burrard,,British Columbia,CA,49.3099,-122.978
 BC118,Eagle Heights,,British Columbia,CA,48.7563,-123.703

--- a/vector_data/point/british_columbia_point_locations.csv
+++ b/vector_data/point/british_columbia_point_locations.csv
@@ -41,7 +41,6 @@ BC40,Stillwater,,British Columbia,CA,49.7667,-124.3
 BC41,Gateway,,British Columbia,CA,51.6808,-121.211
 BC42,Chinook Cove,,British Columbia,CA,51.2333,-120.167
 BC43,Oliver's Landing,,British Columbia,CA,49.5833,-123.221
-BC44,Shuswap,,British Columbia,CA,50.7896,-119.709
 BC45,Rock Bay,,British Columbia,CA,50.3323,-125.486
 BC46,Stump Lake,,British Columbia,CA,50.3883,-120.328
 BC47,Cultus Lake,,British Columbia,CA,49.0714,-121.966
@@ -311,7 +310,6 @@ BC316,Shawl Bay,,British Columbia,CA,50.8433,-126.56
 BC317,Cloverdale,,British Columbia,CA,49.1117,-122.725
 BC318,Dugan Lake,,British Columbia,CA,52.1667,-121.925
 BC319,Cobble Hill,,British Columbia,CA,48.6915,-123.585
-BC320,Shuswap,,British Columbia,CA,50.5268,-116.002
 BC321,Saseenos,,British Columbia,CA,48.3908,-123.669
 BC322,Pritchard,,British Columbia,CA,50.6851,-119.812
 BC323,Oweekeno,,British Columbia,CA,51.6853,-127.207

--- a/vector_data/point/british_columbia_point_locations.csv
+++ b/vector_data/point/british_columbia_point_locations.csv
@@ -13,7 +13,7 @@ BC11,Shelter Bay Ferry Terminal,,British Columbia,CA,50.6358,-117.929
 BC12,Sunnyside,,British Columbia,CA,54.6538,-124.732
 BC13,McDonalds Landing,,British Columbia,CA,54.0,-126.033
 BC14,West Moberly,,British Columbia,CA,55.8272,-121.852
-BC15,Summit Lake,,British Columbia,CA,50.1523,-117.661
+BC15,Summit Lake Provincial Park,,British Columbia,CA,50.1523,-117.661
 BC16,Kelly Lake,,British Columbia,CA,51.0124,-121.7658
 BC17,Kingfisher,,British Columbia,CA,50.6167,-118.733
 BC18,Cooper Creek,,British Columbia,CA,50.2023,-116.963
@@ -29,14 +29,13 @@ BC27,Hills,,British Columbia,CA,50.1089,-117.493
 BC28,Meadows,,British Columbia,CA,49.1859,-117.396
 BC29,93 Mile,,British Columbia,CA,51.5748,-121.341
 BC30,Pineview,,British Columbia,CA,53.8367,-122.658
-BC31,Old Fort,,British Columbia,CA,56.2022,-120.823
+BC31,Old Fort St. John,,British Columbia,CA,56.2022,-120.823
 BC32,Eagle Creek,,British Columbia,CA,51.8597,-120.866
 BC33,Roe Lake,,British Columbia,CA,51.5208,-120.831
 BC34,Coal Harbour,,British Columbia,CA,50.6,-127.583
 BC35,Apex Mountain Resort,,British Columbia,CA,49.3942,-119.907
 BC36,Wiley,,British Columbia,CA,54.515,-126.334
 BC37,Gilpin,,British Columbia,CA,49.0063,-118.329
-BC38,Cherry Creek,,British Columbia,CA,50.7125,-120.625
 BC39,Balmoral,,British Columbia,CA,50.8531,-119.355
 BC40,Stillwater,,British Columbia,CA,49.7667,-124.3
 BC41,Gateway,,British Columbia,CA,51.6808,-121.211
@@ -46,7 +45,6 @@ BC44,Shuswap,,British Columbia,CA,50.7896,-119.709
 BC45,Rock Bay,,British Columbia,CA,50.3323,-125.486
 BC46,Stump Lake,,British Columbia,CA,50.3883,-120.328
 BC47,Cultus Lake,,British Columbia,CA,49.0714,-121.966
-BC48,Silver Creek,,British Columbia,CA,49.3634,-121.456
 BC49,Cheslatta,,British Columbia,CA,53.8167,-125.8
 BC50,White Lake,,British Columbia,CA,50.8798,-119.302
 BC51,Mud Bay,,British Columbia,CA,49.4667,-124.8
@@ -97,7 +95,6 @@ BC95,Commodore Heights,,British Columbia,CA,52.1667,-122.133
 BC96,Porcher Island,,British Columbia,CA,54.0867,-130.392
 BC97,Slesse Park,,British Columbia,CA,49.0805,-121.821
 BC98,Matsqui,,British Columbia,CA,49.006,-122.476
-BC99,Osoyoos,,British Columbia,CA,49.1782,-119.527
 BC100,Garibaldi,,British Columbia,CA,49.9667,-123.15
 BC101,Doig River,,British Columbia,CA,56.5711,-120.494
 BC102,Malahat,,British Columbia,CA,48.6128,-123.523
@@ -117,7 +114,6 @@ BC115,Kitselas,,British Columbia,CA,54.4872,-128.586
 BC116,Toquaht,,British Columbia,CA,48.9959,-125.379
 BC117,Burrard,,British Columbia,CA,49.3099,-122.978
 BC118,Eagle Heights,,British Columbia,CA,48.7563,-123.703
-BC119,Yale,,British Columbia,CA,49.4712,-121.425
 BC120,Mount Robson,,British Columbia,CA,53.0309,-119.228
 BC121,Seton Lake,,British Columbia,CA,50.7047,-122.281
 BC122,Huu-ay-aht,,British Columbia,CA,48.8012,-125.122
@@ -200,7 +196,6 @@ BC198,Saanich,,British Columbia,CA,48.4878,-123.388
 BC199,Bridge Lake,,British Columbia,CA,51.4786,-120.726
 BC200,Halalt,,British Columbia,CA,48.8769,-123.692
 BC201,Surge Narrows,,British Columbia,CA,50.2306,-125.109
-BC202,Spuzzum,,British Columbia,CA,49.6611,-121.414
 BC203,Toad River,,British Columbia,CA,58.85,-125.233
 BC204,Punchaw,,British Columbia,CA,53.4306,-123.182
 BC205,Little Shuswap Lake,,British Columbia,CA,50.8758,-119.612
@@ -241,7 +236,6 @@ BC239,Brouse,,British Columbia,CA,50.2167,-117.75
 BC240,Monte Lake,,British Columbia,CA,50.5254,-119.832
 BC241,Miworth,,British Columbia,CA,53.9399,-122.949
 BC242,Hornby Island,,British Columbia,CA,49.5227,-124.642
-BC243,Soda Creek,,British Columbia,CA,52.3466,-122.292
 BC244,Powder King,,British Columbia,CA,55.3505,-122.615
 BC245,Clearwater,,British Columbia,CA,51.65,-120.033
 BC246,Bouchie Lake,,British Columbia,CA,53.0262,-122.597
@@ -288,7 +282,6 @@ BC286,Penelakut,,British Columbia,CA,48.9749,-123.641
 BC287,Moberly Lake,,British Columbia,CA,55.8333,-121.758
 BC288,Holmwood,,British Columbia,CA,50.6189,-119.954
 BC289,Peachland,,British Columbia,CA,49.7786,-119.736
-BC290,Westbank,,British Columbia,CA,49.8432,-119.616
 BC291,Halfmoon Bay,,British Columbia,CA,49.5146,-123.909
 BC292,Garibaldi Highlands,,British Columbia,CA,49.7417,-123.135
 BC293,Williams Beach,,British Columbia,CA,49.834,-125.061
@@ -355,7 +348,6 @@ BC353,New Westminster,,British Columbia,CA,49.2167,-122.917
 BC354,Blaeberry,,British Columbia,CA,51.4333,-117.067
 BC355,Shutty Bench,,British Columbia,CA,49.9629,-116.907
 BC356,Pope Landing,,British Columbia,CA,49.6145,-124.048
-BC357,Quatsino,,British Columbia,CA,50.5357,-127.652
 BC358,Fair Harbour,,British Columbia,CA,50.0565,-127.101
 BC359,Butedale,,British Columbia,CA,53.15,-128.7
 BC360,Lang Bay,,British Columbia,CA,49.7792,-124.346

--- a/vector_data/point/manitoba_point_locations.csv
+++ b/vector_data/point/manitoba_point_locations.csv
@@ -117,7 +117,6 @@ MB115,Dallas,,Manitoba,CA,51.3922,-97.485
 MB116,Dand,,Manitoba,CA,49.34,-100.5
 MB117,Darlingford,,Manitoba,CA,49.2039,-98.3781
 MB118,Dauphin,,Manitoba,CA,51.1474,-100.0629
-MB119,Dauphin,,Manitoba,CA,51.1494,-100.049
 MB120,Dauphin River,,Manitoba,CA,51.9571,-98.0698
 MB121,Dawson Bay,,Manitoba,CA,52.9767,-100.98
 MB122,Deleau,,Manitoba,CA,49.5811,-100.575
@@ -165,7 +164,6 @@ MB163,Firdale,,Manitoba,CA,49.9822,-99.1097
 MB164,Fisher Bay,,Manitoba,CA,51.4778,-97.2975
 MB165,Fisher Branch,,Manitoba,CA,51.0831,-97.62
 MB166,Fisher River,,Manitoba,CA,51.4377,-97.3911
-MB167,Fisher River,,Manitoba,CA,51.4022,-97.5314
 MB168,Flin Flon,,Manitoba,CA,54.7704,-101.858
 MB169,Fork River,,Manitoba,CA,51.5117,-100.02
 MB170,Forrest,,Manitoba,CA,49.9664,-99.9367
@@ -354,7 +352,6 @@ MB352,Myrtle,,Manitoba,CA,49.3533,-97.8367
 MB353,Napinka,,Manitoba,CA,49.3225,-100.841
 MB354,Narcisse,,Manitoba,CA,50.6833,-97.5297
 MB355,Neelin,,Manitoba,CA,49.2294,-99.3478
-MB356,Neepawa,,Manitoba,CA,50.2287,-99.4746
 MB357,Neepawa,,Manitoba,CA,50.2289,-99.4656
 MB358,Nelson House,,Manitoba,CA,55.7954,-98.8941
 MB359,Nesbitt,,Manitoba,CA,49.6014,-99.8628
@@ -368,8 +365,7 @@ MB366,Ninette,,Manitoba,CA,49.4012,-99.6313
 MB367,Ninga,,Manitoba,CA,49.2275,-99.8894
 MB368,Nisichawayasihk,,Manitoba,CA,55.7833,-98.8883
 MB369,Niverville,,Manitoba,CA,49.6056,-97.0417
-MB370,Norway House,,Manitoba,CA,53.9676,-97.7877
-MB371,Norway House,,Manitoba,CA,53.9804,-97.8273
+MB371,Norway House,,Manitoba,CA,53.9592,-97.8444
 MB372,Notre Dame de Lourdes,,Manitoba,CA,49.5331,-98.5578
 MB373,Nutimik Lake,,Manitoba,CA,50.1475,-95.6914
 MB374,O-Chi-Chak-Ko-Sipi,,Manitoba,CA,51.5041,-99.2579
@@ -401,7 +397,6 @@ MB399,Paradise Village,,Manitoba,CA,49.6694,-96.5767
 MB400,Parkdale,,Manitoba,CA,50.0397,-97.0293
 MB401,Pauingassi,,Manitoba,CA,52.1584,-95.3817
 MB402,Peguis,,Manitoba,CA,51.3086,-97.5574
-MB403,Peguis,,Manitoba,CA,50.2222,-96.8381
 MB404,Pelican Point Beach,,Manitoba,CA,49.3792,-99.6161
 MB405,Pelican Rapids,,Manitoba,CA,52.7428,-100.7
 MB406,Petersfield,,Manitoba,CA,50.3044,-96.9686

--- a/vector_data/point/saskatchewan_point_locations.csv
+++ b/vector_data/point/saskatchewan_point_locations.csv
@@ -150,7 +150,6 @@ SK148,Clair,,Saskatchewan,CA,52.0222,-104.077
 SK149,Clavet,,Saskatchewan,CA,51.9957,-106.374
 SK150,Claybank,,Saskatchewan,CA,50.0455,-105.233
 SK151,Clearwater River,,Saskatchewan,CA,56.5296,-109.492
-SK152,Clearwater River,,Saskatchewan,CA,56.0486,-108.724
 SK153,Clemenceau,,Saskatchewan,CA,52.6652,-102.527
 SK154,Climax,,Saskatchewan,CA,49.2077,-108.388
 SK155,Clouston,,Saskatchewan,CA,53.1,-105.85
@@ -426,7 +425,6 @@ SK424,Kyle,,Saskatchewan,CA,50.8319,-108.038
 SK425,Kylemore,,Saskatchewan,CA,51.9071,-103.641
 SK426,La Loche,,Saskatchewan,CA,56.4858,-109.434
 SK427,La Ronge,,Saskatchewan,CA,55.112,-105.3
-SK428,La Ronge,,Saskatchewan,CA,55.1072,-105.28
 SK429,Lac Vert,,Saskatchewan,CA,52.5035,-104.493
 SK430,Lady Lake,,Saskatchewan,CA,52.0268,-102.626
 SK431,Lafleche,,Saskatchewan,CA,49.7052,-106.574
@@ -547,7 +545,6 @@ SK545,Montreal Lake,,Saskatchewan,CA,54.0456,-105.773
 SK546,Moose Bay,,Saskatchewan,CA,50.6132,-102.685
 SK547,Moose Jaw,,Saskatchewan,CA,50.4,-105.533
 SK548,Moose Range,,Saskatchewan,CA,53.2333,-103.7
-SK549,Moosomin,,Saskatchewan,CA,50.142,-101.67
 SK550,Moosomin,,Saskatchewan,CA,50.1444,-101.667
 SK551,Morse,,Saskatchewan,CA,50.4159,-107.04
 SK552,Mortlach,,Saskatchewan,CA,50.4547,-106.068
@@ -614,7 +611,6 @@ SK612,Parkside,,Saskatchewan,CA,53.1656,-106.536
 SK613,Parkview,,Saskatchewan,CA,50.6172,-105.458
 SK614,Parry,,Saskatchewan,CA,49.7887,-104.72
 SK615,Pasqua Lake,,Saskatchewan,CA,50.7361,-103.98
-SK616,Pasqua Lake,,Saskatchewan,CA,50.7928,-103.961
 SK617,Paswegin,,Saskatchewan,CA,51.9939,-103.965
 SK618,Pathlow,,Saskatchewan,CA,52.7157,-104.805
 SK619,Patuanak,,Saskatchewan,CA,55.8964,-107.705
@@ -759,7 +755,6 @@ SK757,Spring Bay,,Saskatchewan,CA,50.9361,-105.136
 SK758,Spring Valley,,Saskatchewan,CA,49.9432,-105.403
 SK759,Springfeld,,Saskatchewan,CA,50.1419,-107.734
 SK760,Springside,,Saskatchewan,CA,51.345,-102.742
-SK761,Springside,,Saskatchewan,CA,51.3465,-102.743
 SK762,Springwater,,Saskatchewan,CA,51.9727,-108.378
 SK763,Spruce Bay,,Saskatchewan,CA,53.2069,-107.692
 SK764,Spruce Home,,Saskatchewan,CA,53.3941,-105.767

--- a/vector_data/point/yukon_point_locations.csv
+++ b/vector_data/point/yukon_point_locations.csv
@@ -1,7 +1,6 @@
 id,name,alt_name,region,country,latitude,longitude
 YT1,Aishihik,,Yukon,CA,61.5986,-137.508
 YT2,Bear Creek,,Yukon,CA,60.7975,-137.67
-YT3,Bear Creek,,Yukon,CA,60.8023,-137.7001
 YT4,Beaver Creek,,Yukon,CA,62.3833,-140.875
 YT5,Braeburn,,Yukon,CA,61.4815,-135.748
 YT6,Brooks Brook,,Yukon,CA,60.4189,-133.191


### PR DESCRIPTION
This PR should resolve a set of duplicated point name locations. The source of the duplicates was either our initial QA/QC process on these data, the source data we derived from, or in some cases, two actual locations that happen to share the same name.

I checked each CSV file for duplicate names, extracted the duplicates, computed a distance between the coordinate pairs, and then manually validated which point to retain via a Google Maps lookup.

Closes #16, #17, #19, #21, #22