### PR TITLE
Fix "Meyers Chuck" and "Valdez"

### DIFF
--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -259,7 +259,6 @@ AK251,Moose Pass,,Alaska,US,60.4876,-149.367
 AK252,Morzhovoi,,Alaska,US,54.91,-163.303
 AK253,Moses Point,,Alaska,US,64.7002,-162.033
 AK254,Mountain Village,Asaacaryaraq,Alaska,US,62.0884,-163.72
-AK255,Myers Chuck,,Alaska,US,55.742,-132.253
 AK256,Nabesna,Nabaesna’ / Naambia Niign Daacheeg,Alaska,US,62.3719,-143.009
 AK257,Nakeen,,Alaska,US,58.9361,-157.038
 AK258,Naknek,Nakniq,Alaska,US,58.7283,-157.014

--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -425,7 +425,7 @@ AK417,Upper Kalskag,,Alaska,US,61.5372,-160.305
 AK418,Utqiaġvik,Barrow,Alaska,US,71.2905,-156.789
 AK419,Utukakarvik,,Alaska,US,61.9611,-164.75
 AK420,Uyak,,Alaska,US,57.6256,-153.988
-AK421,Valdez,Suacit,Alaska,US,61.1308,-146.348
+AK421,Valdez,Suacit,Alaska,US,61.1369,-146.3471
 AK422,Venetie,Vįįhtąįį,Alaska,US,67.0139,-146.419
 AK423,Wainwright,Ulġuniq,Alaska,US,70.6369,-160.038
 AK424,Wales,Kiŋigin,Alaska,US,65.6097,-168.0876


### PR DESCRIPTION
Minor PR to de-duplicate the "Meyers" and "Myers" Chuck place names. The former is preferred based on my research. Valdez point location is adjusted 800 m to reduce raster sampling conflicts (e.g. point was close to the coast and looks like ocean / no data in a sufficiently coarse raster grid).

Closes #33 
Closes #35