### PR TITLE
add distance to ocean (km) column for all rows

### DIFF
--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -1,449 +1,449 @@
-id,name,alt_name,region,country,latitude,longitude
-AK1,Afognak,Agw’aneq,Alaska,US,58.0078,-152.768
-AK2,Akhiok,Kasukuak,Alaska,US,56.9455,-154.17
-AK3,Akiachak,Akiacuar,Alaska,US,60.9094,-161.431
-AK4,Akiak,Akiaq,Alaska,US,60.9122,-161.214
-AK5,Akutan,Achan-ingiiga,Alaska,US,54.1385,-165.778
-AK6,Alakanuk,Alarneq,Alaska,US,62.6889,-164.615
-AK7,Alatna,Alaasuq,Alaska,US,66.5542,-152.7019
-AK8,Aleknagik,Alaqnaqiq,Alaska,US,59.273,-158.618
-AK9,Aleut Village,,Alaska,US,58.0171,-152.761
-AK10,Alexander Creek,,Alaska,US,61.4171,-150.593
-AK11,Allakaket,Aalaa Kkaakk’et,Alaska,US,66.5656,-152.646
-AK12,Ambler,Ivisaappaat,Alaska,US,67.0861,-157.851
-AK13,Anaktuvuk Pass,Anaqtuuvak / Naqsraq,Alaska,US,68.1433,-151.736
-AK14,Anchor Point,,Alaska,US,59.7766,-151.831
-AK15,Anchorage,Dgheyaytnu,Alaska,US,61.1817,-149.993
-AK16,Anderson,,Alaska,US,64.3441,-149.187
-AK18,Angoon,Aangóon,Alaska,US,57.5033,-134.584
-AK19,Aniak,Anyaraq,Alaska,US,61.5783,-159.522
-AK20,Annette,,Alaska,US,55.063,-131.541
-AK21,Anvik,Gitr’ingith Chagg,Alaska,US,62.6561,-160.207
-AK22,Arctic Village,Vashrąįį K'ǫǫ,Alaska,US,68.1269,-145.538
-AK23,Atka,Atx̂ax̂,Alaska,US,52.191,-174.189
-AK24,Atmautluak,Atmaulluaq,Alaska,US,60.8641,-162.2723
-AK25,Atqasuk,,Alaska,US,70.4694,-157.396
-AK26,Attu,,Alaska,US,52.9365,173.24
-AK27,Auke Bay,,Alaska,US,58.383,-134.657
-AK28,Ayakulik,,Alaska,US,57.2113,-154.546
-AK29,Baranof Warm Springs,,Alaska,US,57.0895,-134.8337
-AK30,Bartlett Cove,,Alaska,US,58.45,-135.916
-AK31,Beaver,Ts'aahudaaneekk'onh Denh,Alaska,US,66.3594,-147.396
-AK444,Beecher Pass State Marine Park,,Alaska,US,56.6003,-133.0267
-AK32,Belkofski,Taxtamax̂,Alaska,US,55.0905,-162.034
-AK33,Bell Island Hot Springs,,Alaska,US,55.933,-131.566
-AK35,Bessie No. 5 Dredge,,Alaska,US,64.5502,-165.151
-AK36,Bethel,Mamterilleq,Alaska,US,60.7922,-161.756
-AK37,Bettles,Kk’odlel T’odegheelenh Denh,Alaska,US,66.9185,-151.5162
-AK445,Bettles Bay State Marine Park,,Alaska,US,60.9597,-148.3184
-AK38,Big Delta,,Alaska,US,64.1525,-145.842
-AK39,Big Lake,,Alaska,US,61.5378,-149.824
-AK40,Bill Moore's Slough,,Alaska,US,62.9504,-163.7777
-AK41,Biorka,,Alaska,US,53.831,-166.208
-AK42,Birch Creek,Łiteet'aii,Alaska,US,66.2687,-145.824
-AK43,Birchwood,,Alaska,US,61.4081,-149.481
-AK44,Bird Point,,Alaska,US,60.9311,-149.358
-AK45,Bodenburg Butte,,Alaska,US,61.5495,-149.047
-AK46,Boswell Bay,,Alaska,US,60.4001,-146.133
-AK47,Brevig Mission,Sitaisaq,Alaska,US,65.3347,-166.489
-AK48,Buckland,Kaŋiq,Alaska,US,65.9797,-161.123
-AK49,Candle,,Alaska,US,65.9133,-161.924
-AK50,Cantwell,Yidateni Na’,Alaska,US,63.3917,-148.951
-AK51,Cape Lisburne,,Alaska,US,68.8678,-166.193
-AK52,Cape Pole,,Alaska,US,55.965,-133.798
-AK53,Cape Yakataga,,Alaska,US,60.0652,-142.428
-AK54,Central,,Alaska,US,65.5724,-144.803
-AK55,Chakaktolik,,Alaska,US,61.7711,-163.625
-AK56,Chakwaktolik,,Alaska,US,61.2291,-163.754
-AK57,Chalkyitsik,Jałgiitsik,Alaska,US,66.6544,-143.722
-AK58,Chaniliut,,Alaska,US,63.0332,-163.417
-AK60,Chatham,,Alaska,US,57.514,-134.924
-AK61,Chefornak,Cevvʼarneq / Caputnguaq,Alaska,US,60.1607,-164.271
-AK62,Chena Hot Springs,,Alaska,US,65.053,-146.056
-AK63,Chenega Bay,Caniqaq,Alaska,US,60.0746,-148.003
-AK64,Chevak,Cevʼaq,Alaska,US,61.5278,-165.586
-AK65,Chickaloon,Nay’dini’aa Na’,Alaska,US,61.7967,-148.463
-AK66,Chicken,,Alaska,US,64.0733,-141.936
-AK67,Chignik,Cirniq,Alaska,US,56.2953,-158.402
-AK68,Chignik Lagoon,Nanwarnaq,Alaska,US,56.3104,-158.5361
-AK69,Chignik Lake,Igyaraq,Alaska,US,56.2552,-158.7696
-AK446,Chilkat River Critical Habitat Area,,Alaska,US,59.373,-135.8596
-AK70,Chiniak,,Alaska,US,57.617,-152.2166
-AK71,Chisana,,Alaska,US,62.0671,-142.049
-AK72,Chistochina,Tsiis Tl’edze’ Caegge,Alaska,US,62.565,-144.665
-AK73,Chitina,Tsedi Na',Alaska,US,61.5158,-144.437
-AK74,Christian,,Alaska,US,67.3673,-145.2
-AK75,Chuathbaluk,Curarpalek,Alaska,US,61.5726,-159.235
-AK447,Chugach National Forest Municipal Watershed,,Alaska,US,60.5195,-145.7223
-AK76,Chuloonawick,,Alaska,US,62.8961,-163.894
-AK77,Circle,Danzhit Khànląįį,Alaska,US,65.8255,-144.061
-AK78,Circle Hot Springs,,Alaska,US,65.4833,-144.634
-AK79,Clam Gulch,,Alaska,US,60.2311,-151.394
-AK80,Clark's Point,Saguyaq,Alaska,US,58.8441,-158.551
-AK81,Clear,,Alaska,US,64.3332,-149.167
-AK82,Clover Pass,,Alaska,US,55.472,-131.791
-AK83,Coffman Cove,,Alaska,US,56.0119,-132.8296
-AK84,Cohoe,,Alaska,US,60.3671,-151.3
-AK85,Cold Bay,,Alaska,US,55.1858,-162.721
-AK86,College,,Alaska,US,64.8582,-147.808
-AK87,Cooper Landing,,Alaska,US,60.4906,-149.833
-AK88,Copper Center,Tl’aticae’e,Alaska,US,61.955,-145.305
-AK89,Cordova,,Alaska,US,60.5428,-145.757
-AK90,Council,,Alaska,US,64.895,-163.676
-AK91,Craig,Sháan Séet,Alaska,US,55.4764,-133.148
-AK92,Crooked Creek,Qipcarpak,Alaska,US,61.87,-158.111
-AK448,Dall Bay State Marine Park,,Alaska,US,55.1559,-131.749
-AK93,Deadhorse,,Alaska,US,70.2097,-148.418
-AK449,Decision Point State Marine Park,,Alaska,US,60.8016,-148.464
-AK94,Deering,Ipnatchiaq,Alaska,US,66.0755,-162.717
-AK95,Delta Junction,,Alaska,US,64.0377,-145.732
-AK96,Dillingham,Curyung,Alaska,US,59.0397,-158.457
-AK97,Diomede,Iŋaliq,Alaska,US,65.7648,-168.911
-AK98,Dot Lake,Kelt’aaddh Menn’,Alaska,US,63.663,-144.049
-AK99,Douglas,,Alaska,US,58.2762,-134.392
-AK100,Dry Creek,,Alaska,US,63.7,-144.567
-AK101,Dutch Harbor,,Alaska,US,53.891,-166.535
-AK102,Eagle,Tthee T'äwdlenn,Alaska,US,64.788,-141.2
-AK103,Eagle River,,Alaska,US,61.3221,-149.567
-AK104,Eagle Village,,Alaska,US,64.7805,-141.114
-AK441,Eareckson Air Station,,Alaska,US,52.7122,174.1136
-AK105,Edna Bay,,Alaska,US,55.9489,-133.662
-AK106,Eek,Ekvicuaq,Alaska,US,60.2189,-162.024
-AK107,Egavik,,Alaska,US,64.0332,-160.917
-AK108,Egegik,Igyagiiq,Alaska,US,58.2155,-157.376
-AK109,Egorkovskoi,,Alaska,US,53.564,-168.0
-AK442,Eielson Air Force Base,,Alaska,US,64.6656,-147.1014
-AK110,Eklutna,Idlughet,Alaska,US,61.458,-149.362
-AK111,Ekuk,,Alaska,US,58.804,-158.541
-AK112,Ekwok,Iquaq,Alaska,US,59.3497,-157.475
-AK113,Elephant Point,,Alaska,US,66.2673,-161.333
-AK114,Elfin Cove,,Alaska,US,58.1944,-136.343
-AK115,Elim,Neviarcaurluq,Alaska,US,64.6175,-162.26
-AK116,Ellamar,,Alaska,US,60.8961,-146.708
-AK117,Emmonak,Imangaq,Alaska,US,62.7778,-164.523
-AK450,Ernie Haugen Public Use Area,,Alaska,US,56.5421,-132.6616
-AK119,Eska,,Alaska,US,61.7381,-148.906
-AK120,Ester,,Alaska,US,64.8472,-148.014
-AK122,Excursion Inlet,,Alaska,US,58.417,-135.441
-AK123,Eyak,Igya’aq,Alaska,US,60.5652,-145.7
-AK124,Fairbanks,,Alaska,US,64.8378,-147.716
-AK125,False Pass,Isanax̂,Alaska,US,54.8548,-163.407
-AK126,Ferry,,Alaska,US,64.0172,-149.117
-AK127,Fish Village,,Alaska,US,62.5212,-163.847
-AK128,Flat,,Alaska,US,62.4536,-158.007
-AK129,Fort Glenn,,Alaska,US,53.3956,-167.881
-AK440,Fort Greely,,Alaska,US,63.9731,-145.7181
-AK438,Fort Wainwright,,Alaska,US,64.8278,-147.6429
-AK130,Fort Yukon,Gwichyaa Zheh,Alaska,US,66.5647,-145.274
-AK131,Fox,,Alaska,US,64.958,-147.618
-AK451,Funter Bay State Marine Park,,Alaska,US,58.2505,-134.9227
-AK132,Gakona,Ggax Kuna’,Alaska,US,62.3019,-145.302
-AK133,Galena,Notaalee Denh,Alaska,US,64.7333,-156.927
-AK134,Gambell,Sivuqaq,Alaska,US,63.7797,-171.741
-AK135,Georgetown,,Alaska,US,61.9085,-157.787
-AK136,Girdwood,,Alaska,US,60.9421,-149.167
-AK137,Glennallen,,Alaska,US,62.1092,-145.546
-AK452,Goldstream Public Use Area,,Alaska,US,64.93,-147.7653
-AK138,Golovin,Cingik / Siŋik,Alaska,US,64.5433,-163.029
-AK139,Goodnews Bay,Mamterat,Alaska,US,59.1186,-161.589
-AK140,Grayling,Sixno' Xidakagg,Alaska,US,62.9062,-160.077
-AK141,Gulkana,C'uul C'ena',Alaska,US,62.2714,-145.382
-AK142,Gustavus,,Alaska,US,58.4125,-135.738
-AK143,Haines,Deishú,Alaska,US,59.2358,-135.445
-AK145,Haycock,,Alaska,US,65.2172,-161.167
-AK146,Healy,,Alaska,US,63.8578,-148.966
-AK147,Healy Lake,Mendees Cheeg,Alaska,US,63.9441,-144.755
-AK148,Highland Park,,Alaska,US,64.7582,-147.371
-AK149,Holikachuk,,Alaska,US,62.9112,-159.517
-AK150,Hollis,,Alaska,US,55.4879,-132.663
-AK151,Holy Cross,Ingirraller / Deloy Chet,Alaska,US,62.1994,-159.771
-AK152,Homer,,Alaska,US,59.6425,-151.548
-AK153,Hoonah,Xunaa / Gaaw Yat’aḵ Aan,Alaska,US,58.11,-135.444
-AK154,Hooper Bay,Naparyaarmiut,Alaska,US,61.5311,-166.097
-AK155,Hope,,Alaska,US,60.9203,-149.64
-AK156,Houston,,Alaska,US,61.6302,-149.818
-AK157,Hughes,Hut’odlee Kkaakk’et,Alaska,US,66.0488,-154.255
-AK158,Huslia,Ts’aateyhdenaadekk’onh Denh,Alaska,US,65.6986,-156.4
-AK159,Hydaburg,Higdáa G̱ándlaay,Alaska,US,55.208,-132.827
-AK160,Hyder,,Alaska,US,55.9169,-130.025
-AK161,Iditarod,,Alaska,US,62.5448,-158.094
-AK162,Igiugig,Igyaraq,Alaska,US,59.3278,-155.895
-AK163,Ikatan,,Alaska,US,54.75,-163.308
-AK164,Iliamna,Illiamna,Alaska,US,59.7536,-154.817
-AK165,Inakpuk,,Alaska,US,59.5331,-157.15
-AK166,Indian,,Alaska,US,60.9881,-149.513
-AK167,Indian River,,Alaska,US,62.6672,-144.433
-AK168,Ingrihak,,Alaska,US,61.7561,-162.0
-AK169,Ivanof Bay,,Alaska,US,55.8996,-159.507
-AK453,Joe Mace Island State Marine Park,,Alaska,US,56.3473,-133.635
-AK170,Joe Ward Camp,,Alaska,US,66.8673,-143.699
-AK439,Joint Base Elmendorf-Richardson,,Alaska,US,61.2514,-149.8064
-AK171,Jonesville,,Alaska,US,61.7311,-148.933
-AK172,Juneau,Dzánti K'ihéeni,Alaska,US,58.3019,-134.42
-AK173,Kachemak,,Alaska,US,59.6488,-151.451
-AK174,Kake,Ḵéex̱ʼ,Alaska,US,56.9758,-133.947
-AK176,Kaktovik,Qaaktuġvik,Alaska,US,70.1319,-143.624
-AK177,Kalifornsky,Unhghenesditnu,Alaska,US,60.4412,-151.198
-AK179,Kaltag,Ggaał Doh,Alaska,US,64.3272,-158.722
-AK180,Kanakanak,,Alaska,US,59.0031,-158.533
-AK443,Kantishna,,Alaska,US,63.5253,-150.9581
-AK454,Kanuti Hot Springs Area Of Critical Environmental Concern,,Alaska,US,66.3427,-150.8468
-AK181,Karluk,Kal’ut,Alaska,US,57.5719,-154.455
-AK182,Kasaan,Gasa'áan,Alaska,US,55.5389,-132.401
-AK183,Kashega,,Alaska,US,53.467,-167.16
-AK184,Kashegelok,,Alaska,US,60.8331,-157.833
-AK185,Kasigluk,Kassigluq,Alaska,US,60.8955,-162.521
-AK186,Kasilof,,Alaska,US,60.3375,-151.274
-AK187,Kathakne,,Alaska,US,62.9692,-141.832
-AK188,Kenai,Shk'ituk't,Alaska,US,60.5544,-151.258
-AK189,Kenny Lake,,Alaska,US,61.7379,-144.945
-AK190,Kepangalook,,Alaska,US,60.8501,-161.617
-AK191,Ketchikan,Kichx̱áan,Alaska,US,55.3422,-131.646
-AK192,Kiana,Katyaaq,Alaska,US,66.975,-160.423
-AK193,Kinegnak,,Alaska,US,58.8331,-161.667
-AK194,King Cove,Agdaaĝux̂,Alaska,US,55.0629,-162.31
-AK195,King Island,Ugiuvak,Alaska,US,64.9694,-168.065
-AK196,King Salmon,,Alaska,US,58.6883,-156.661
-AK197,Kipnuk,Qipnek,Alaska,US,59.9389,-164.041
-AK198,Kivalina,Kivaliñiq,Alaska,US,67.7269,-164.533
-AK199,Kiwalik,,Alaska,US,66.0333,-161.833
-AK200,Klawock,Lawaak,Alaska,US,55.5522,-133.096
-AK201,Klery Creek,,Alaska,US,67.1793,-160.4
-AK202,Klukwan,Tlákw.aan,Alaska,US,59.3991,-135.894
-AK203,Knik,,Alaska,US,61.4578,-149.729
-AK204,Kobuk,Laugviik,Alaska,US,66.9072,-156.881
-AK205,Kodiak,Sun'aq,Alaska,US,57.79,-152.407
-AK206,Kokhanok,Qarr’unaq,Alaska,US,59.4426,-154.761
-AK207,Kokrines,Łoyh Denlekk’es Denh,Alaska,US,64.9332,-154.7
-AK208,Koliganek,Qalirneq,Alaska,US,59.7286,-157.284
-AK209,Kongiganak,Kangirnaq,Alaska,US,59.9647,-162.877
-AK210,Kotlik,Qerrulliik,Alaska,US,63.0341,-163.553
-AK211,Kotzebue,Qikiqtaġruk,Alaska,US,66.8983,-162.597
-AK212,Koyuk,Kuuyuk,Alaska,US,64.9319,-161.157
-AK213,Koyukuk,Meneelghaadze’ T’oh,Alaska,US,64.8802,-157.701
-AK214,Kupreanof,,Alaska,US,56.8153,-133.006
-AK215,Kustatan,Qezdeghnen,Alaska,US,60.7171,-151.75
-AK216,Kvichak,,Alaska,US,58.9671,-156.933
-AK217,Kwethluk,Kuiggluk,Alaska,US,60.8122,-161.436
-AK218,Kwigillingok,Kuigilnguq,Alaska,US,59.8644,-163.134
-AK219,Kwiguk,,Alaska,US,62.7683,-164.5067
-AK220,Lake Minchumina,Menchuh Mene’,Alaska,US,63.8828,-152.312
-AK455,Lake Todatonten Pingos Research Natural Area,,Alaska,US,66.1055,-152.938
-AK221,Larsen Bay,Uyaqsaq,Alaska,US,57.54,-153.979
-AK222,Last Tetlin Village,,Alaska,US,63.0332,-142.616
-AK223,Latouche,,Alaska,US,60.0511,-147.9
-AK225,Lena Beach,,Alaska,US,58.393,-134.746
-AK226,Levelock,Liivlek,Alaska,US,59.115,-156.857
-AK227,Libbyville,,Alaska,US,58.7781,-157.056
-AK228,Lime Village,Hekdichen Hdakaq',Alaska,US,61.3564,-155.436
-AK229,Livengood,,Alaska,US,65.5244,-148.545
-AK230,Loring,,Alaska,US,55.603,-131.632
-AK231,Lower Kalskag,Qalqaq,Alaska,US,61.5122,-160.358
-AK232,Lower Tonsina,Kentsii Cae'e,Alaska,US,61.655,-144.659
-AK233,Lucky Shot Landing,,Alaska,US,61.7751,-149.408
-AK234,Manley Hot Springs,Too Naaleł Denh,Alaska,US,65.0011,-150.634
-AK235,Manokotak,Manuquutaq,Alaska,US,58.9796,-159.053
-AK236,Mansfield Village,Dihthâad,Alaska,US,63.4672,-143.433
-AK237,Marshall,Masserculleq,Alaska,US,61.8778,-162.081
-AK238,Marys Igloo,,Alaska,US,65.1478,-165.063
-AK239,Matanuska,,Alaska,US,61.5421,-149.229
-AK240,McCarthy,,Alaska,US,61.4333,-142.922
-AK241,McGrath,Tochak’,Alaska,US,62.9564,-155.596
-AK242,McKinley Park Airport,,Alaska,US,63.7331,-148.9111
-AK243,Meakerville,,Alaska,US,60.5421,-145.008
-AK244,Medfra,,Alaska,US,63.1067,-154.714
-AK245,Mekoryuk,Mikuryar,Alaska,US,60.388,-166.185
-AK246,Mendeltna,,Alaska,US,62.0487,-146.5386
-AK247,Mentasta Lake,Mendaesde,Alaska,US,62.9212,-143.792
-AK248,Metlakatla,Maxłakxaała,Alaska,US,55.1292,-131.572
-AK249,Meyers Chuck,,Alaska,US,55.7408,-132.256
-AK250,Minto,,Alaska,US,65.1496,-149.3504
-AK251,Moose Pass,,Alaska,US,60.4876,-149.367
-AK252,Morzhovoi,,Alaska,US,54.91,-163.303
-AK253,Moses Point,,Alaska,US,64.7002,-162.033
-AK254,Mountain Village,Asaacaryaraq,Alaska,US,62.0884,-163.72
-AK256,Nabesna,Naambia Niign Daacheeg,Alaska,US,62.3719,-143.009
-AK257,Nakeen,,Alaska,US,58.9361,-157.038
-AK258,Naknek,Nakniq,Alaska,US,58.7283,-157.014
-AK259,Nanwalek,English Bay,Alaska,US,59.354,-151.916
-AK261,Napakiak,Naparyarraq,Alaska,US,60.6967,-161.952
-AK262,Napaimute,,Alaska,US,61.54,-158.674
-AK263,Napaskiak,Napaskiaq,Alaska,US,60.708,-161.766
-AK264,Nash Harbor,,Alaska,US,60.2041,-166.939
-AK265,Nelchina,,Alaska,US,61.996,-146.8203
-AK266,Nelson Lagoon,Niilsanam Alĝuudaa,Alaska,US,56.0012,-161.201
-AK267,Nenana,Toghotili,Alaska,US,64.5638,-149.093
-AK268,New Knockhock,,Alaska,US,62.1291,-164.894
-AK269,New Stuyahok,Cetuyaraq,Alaska,US,59.4528,-157.312
-AK270,Newhalen,Nuuriileng,Alaska,US,59.72,-154.897
-AK271,Newtok,Niugtaq,Alaska,US,60.9427,-164.629
-AK272,Nightmute,Negtemiut,Alaska,US,60.4794,-164.724
-AK273,Nikiski,,Alaska,US,60.6394,-151.334
-AK274,Nikolaevsk,,Alaska,US,59.8109,-151.623
-AK275,Nikolai,Nikolai,Alaska,US,63.0133,-154.375
-AK276,Nikolski,Chalukax̂,Alaska,US,52.938,-168.868
-AK277,Nilikluguk,,Alaska,US,60.6501,-165.15
-AK278,Ninilchik,,Alaska,US,60.0514,-151.669
-AK279,Noatak,Nuataam Kuuŋa,Alaska,US,67.5711,-162.965
-AK280,Nome,Sitŋasuaq,Alaska,US,64.5107,-165.4447
-AK281,Nondalton,Nundaltin,Alaska,US,59.9736,-154.846
-AK282,Noorvik,Nuurvik,Alaska,US,66.8383,-161.033
-AK283,North Pole,,Alaska,US,64.7511,-147.349
-AK284,Northway,K’ehtthiign,Alaska,US,62.9616,-141.937
-AK285,Northway Indian Village,,Alaska,US,62.9832,-141.949
-AK286,Northway Junction,,Alaska,US,63.0173,-141.792
-AK287,Nuiqsut,Nuiqsat,Alaska,US,70.2175,-150.976
-AK288,Nulato,Noolaaghe Doh,Alaska,US,64.7194,-158.103
-AK289,Nunam Iqua,Sheldon Point,Alaska,US,62.5336,-164.841
-AK290,Nunapitchuk,Nunapicuar,Alaska,US,60.8969,-162.459
-AK291,Nyac,,Alaska,US,61.0061,-159.946
-AK292,Ohogamiut,Urr'agmiut,Alaska,US,61.5677,-161.864
-AK293,Old Harbor,Nuniaq,Alaska,US,57.2028,-153.304
-AK294,Old Minto,Menhti Xwghotthit,Alaska,US,64.8882,-149.182
-AK456,Oliver Inlet State Marine Park,,Alaska,US,58.1015,-134.3127
-AK295,Ophir,,Alaska,US,63.1447,-156.519
-AK296,Oscarville,Kuiggayagaq,Alaska,US,60.7273,-161.79
-AK297,Osviak,,Alaska,US,58.8171,-161.3
-AK298,Ouzinkie,Uusenkaa,Alaska,US,57.9236,-152.496
-AK299,Paimiut,Paimute,Alaska,US,61.6971,-165.83
-AK300,Palmer,,Alaska,US,61.5997,-149.113
-AK301,Pastolik,,Alaska,US,62.9972,-163.304
-AK302,Pauloff Harbor,,Alaska,US,54.4589,-162.7
-AK303,Paxson,,Alaska,US,63.033,-145.4979
-AK304,Pedro Bay,,Alaska,US,59.7914,-154.098
-AK305,Pelican,K'udeis'x̱'e,Alaska,US,57.9608,-136.227
-AK306,Pennock Island,,Alaska,US,55.328,-131.628
-AK307,Perryville,Perry-q,Alaska,US,55.9119,-159.166
-AK308,Petersburg,Séet Ká,Alaska,US,56.8125,-132.955
-AK309,Petersville,,Alaska,US,62.373,-150.7332
-AK310,Pile Bay Village,,Alaska,US,59.7789,-153.8819
-AK311,Pilot Point,Agisaq,Alaska,US,57.5641,-157.579
-AK312,Pilot Station,Tuutalgaq,Alaska,US,61.9389,-162.875
-AK313,Pitkas Point,Negeqliim Painga,Alaska,US,62.0328,-163.288
-AK314,Platinum,Arviiq,Alaska,US,59.013,-161.816
-AK315,Point Baker,,Alaska,US,56.3528,-133.621
-AK316,Point Hope,Tikiġaq,Alaska,US,68.3477,-166.808
-AK317,Point Lay,Kali,Alaska,US,69.7574,-163.051
-AK318,Poorman,,Alaska,US,64.0991,-155.544
-AK319,Port Alexander,,Alaska,US,56.2497,-134.644
-AK320,Port Alsworth,,Alaska,US,60.2025,-154.313
-AK321,Port Ashton,,Alaska,US,60.0581,-148.05
-AK322,Port Graham,Paluwik,Alaska,US,59.3514,-151.83
-AK323,Port Heiden,Masrriq,Alaska,US,56.9566,-158.645
-AK324,Port Lions,Masiqsirraq,Alaska,US,57.8675,-152.882
-AK325,Port Mackenzie,,Alaska,US,61.2686,-149.9202
-AK326,Port Moller,,Alaska,US,55.99,-160.577
-AK327,Port Protection,,Alaska,US,56.3127,-133.602
-AK328,Portage,,Alaska,US,60.8381,-148.979
-AK329,Portage Creek,,Alaska,US,58.9006,-157.714
-AK330,Portlock,,Alaska,US,59.2144,-151.7461
-AK331,Prudhoe Bay,,Alaska,US,70.2366,-148.38
-AK332,Quinhagak,Kuinerraq,Alaska,US,59.7489,-161.916
-AK333,Rainbow,,Alaska,US,61.0041,-149.642
-AK334,Rampart,Dleł Taaneets,Alaska,US,65.5049,-150.17
-AK335,Red Devil,,Alaska,US,61.7611,-157.313
-AK336,Refuge Cove,,Alaska,US,55.407,-131.741
-AK337,Ruby,Tl'aa'ologhe,Alaska,US,64.7394,-155.487
-AK338,Russian Mission,Iqugmiut,Alaska,US,61.7856,-161.325
-AK457,Safety Cove State Marine Park,,Alaska,US,59.9819,-149.2235
-AK339,Saint George,Anĝaaxchalux̂,Alaska,US,56.603,-169.545
-AK340,Saint Mary's,Negeqliq,Alaska,US,62.053,-163.166
-AK341,Saint Michael,Taciq,Alaska,US,63.478,-162.039
-AK342,Saint Paul,Tanax̂ Amix̂,Alaska,US,57.1221,-170.276
-AK343,Salamatof,,Alaska,US,60.5878,-151.326
-AK344,Salcha,Soł Chaget,Alaska,US,64.5288,-146.899
-AK345,Salt Chuck,,Alaska,US,55.628,-132.552
-AK346,Sanak,,Alaska,US,54.4831,-162.814
-AK347,Sand Point,,Alaska,US,55.3397,-160.497
-AK458,Sandspit Point State Marine Park,,Alaska,US,59.9378,-149.318
-AK348,Savonoski,,Alaska,US,58.7171,-156.867
-AK349,Savoonga,Sivunga,Alaska,US,63.6904,-170.481
-AK350,Saxman,,Alaska,US,55.3183,-131.596
-AK351,Scammon Bay,Marayaarmiut,Alaska,US,61.8428,-165.582
-AK352,Selawik,Siiḷivik / Akuliġaq,Alaska,US,66.6039,-160.007
-AK353,Seldovia,Angagkitaqnuuq,Alaska,US,59.438,-151.711
-AK354,Seward,Qutalleq,Alaska,US,60.1043,-149.442
-AK355,Shageluk,Edixi,Alaska,US,62.6822,-159.562
-AK356,Shaktoolik,Saktuliq,Alaska,US,64.35,-161.183
-AK357,Shemya Station,,Alaska,US,52.7246,174.112
-AK358,Shishmaref,Qigiqtaq,Alaska,US,66.2567,-166.072
-AK359,Shungnak,Isiŋnaq / Nuurviuraq,Alaska,US,66.888,-157.136
-AK360,Sitka,Sheet'ká,Alaska,US,57.053,-135.33
-AK361,Skagway,,Alaska,US,59.4583,-135.314
-AK362,Skwentna,,Alaska,US,61.9649,-151.158
-AK363,Slana,Stl’aa Caegge,Alaska,US,62.707,-143.9697
-AK365,Sleetmute,Cellitemiut,Alaska,US,61.7025,-157.17
-AK366,Soldotna,,Alaska,US,60.4878,-151.058
-AK367,Solomon,,Alaska,US,64.5608,-164.439
-AK368,South Naknek,Qinuyang,Alaska,US,58.7155,-156.998
-AK459,South Todatonten Summit Research Natural Area,,Alaska,US,66.0506,-152.881
-AK369,Spenard,,Alaska,US,61.1881,-149.917
-AK370,Squaw Harbor,,Alaska,US,55.2433,-160.553
-AK371,St. Mary's,,Alaska,US,62.0331,-163.25
-AK460,Stan Price State Wildlife Sanctuary,,Alaska,US,57.9051,-134.275
-AK372,Stebbins,Tapraq,Alaska,US,63.5222,-162.288
-AK373,Sterling,,Alaska,US,60.5381,-150.758
-AK374,Stevens Village,Denyeet,Alaska,US,66.0063,-149.091
-AK375,Stony River,Gidighuyghatno’ Xidochagg Qay / K'qizaghetnu,Alaska,US,61.7831,-156.588
-AK376,Summit,,Alaska,US,63.3292,-149.119
-AK461,Sunny Cove State Marine Park,,Alaska,US,59.9024,-149.3453
-AK377,Sunrise,,Alaska,US,60.8921,-149.425
-AK378,Suntrana,,Alaska,US,63.8582,-148.846
-AK379,Susitna Station,,Alaska,US,61.5432,-150.5162
-AK380,Sutton,,Alaska,US,61.7114,-148.894
-AK381,Takotna,Tochotno’,Alaska,US,62.9886,-156.064
-AK462,Taku Harbor State Marine Park,,Alaska,US,58.0622,-134.0187
-AK382,Talkeetna,K'dalkitnu,Alaska,US,62.3239,-150.109
-AK383,Tanacross,Taats’altęy,Alaska,US,63.378,-143.356
-AK384,Tanana,Hohudodetlaatl Denh,Alaska,US,65.1719,-152.079
-AK386,Tatitlek,Taatiilaaq,Alaska,US,60.8647,-146.679
-AK387,Tazlina,Tezdlen Na’,Alaska,US,62.0305,-145.416
-AK388,Tee Harbor,,Alaska,US,58.41,-134.757
-AK389,Telida,Tilayadi,Alaska,US,63.3833,-153.267
-AK390,Teller,Tala,Alaska,US,65.2636,-166.361
-AK392,Tenakee Springs,Tʼanag̱eey / Tlaagoowu Aan,Alaska,US,57.7808,-135.219
-AK393,Tetlin,Teełąy,Alaska,US,63.1373,-142.5208
-AK394,Tetlin Junction,,Alaska,US,63.3172,-142.599
-AK395,Thane,,Alaska,US,58.264,-134.328
-AK396,Thorne Bay,,Alaska,US,55.7274,-132.471
-AK463,Thumb Cove State Marine Park,,Alaska,US,60.004,-149.3008
-AK397,Tin City,,Alaska,US,65.5502,-167.851
-AK398,Togiak,Tuyuryaq,Alaska,US,59.0619,-160.376
-AK399,Tok,,Alaska,US,63.3366,-142.985
-AK400,Tokeen,,Alaska,US,55.938,-133.324
-AK401,Toksook Bay,Nunakauyaq,Alaska,US,60.5303,-165.102
-AK402,Tolovana,,Alaska,US,64.8542,-149.824
-AK403,Tonsina,,Alaska,US,61.6558,-145.175
-AK404,Tuluksak,Tuulkessaaq,Alaska,US,61.1025,-160.962
-AK405,Tuntutuliak,Tuntutuliaq,Alaska,US,60.3397,-162.669
-AK406,Tununak,Tununeq,Alaska,US,60.5855,-165.256
-AK407,Twin Hills,Ingricuar,Alaska,US,59.0792,-160.275
-AK436,Two Rivers,,Alaska,US,64.8767,-147.0384
-AK408,Tyonek,Qaggeyshlat,Alaska,US,61.0681,-151.137
-AK409,Ugashik,Ugaasaq,Alaska,US,57.513,-157.397
-AK411,Umiat,,Alaska,US,69.3674,-152.133
-AK412,Umkumiute,,Alaska,US,60.4983,-165.199
-AK413,Umnak,,Alaska,US,53.267,-168.217
-AK414,Unalakleet,Uŋalaqłiit,Alaska,US,63.873,-160.788
-AK415,Unalaska,Iluulux̂,Alaska,US,53.8733,-166.533
-AK416,Unga,Uĝnaasaqax̂,Alaska,US,55.1828,-160.506
-AK178,Upper Kalskag,Qalqaq,Alaska,US,61.5391,-160.306
-AK418,Utqiaġvik,Barrow,Alaska,US,71.2905,-156.789
-AK419,Utukakarvik,,Alaska,US,61.9611,-164.75
-AK420,Uyak,,Alaska,US,57.6256,-153.988
-AK421,Valdez,Suacit,Alaska,US,61.1369,-146.3471
-AK422,Venetie,Vįįhtąįį,Alaska,US,67.0139,-146.419
-AK423,Wainwright,Ulġuniq,Alaska,US,70.6369,-160.038
-AK424,Wales,Kiŋigin,Alaska,US,65.6097,-168.0876
-AK425,Ward Cove,,Alaska,US,55.408,-131.724
-AK426,Wasilla,,Alaska,US,61.5814,-149.439
-AK427,Whale Pass,,Alaska,US,56.1,-133.167
-AK428,White Mountain,Nasirvik,Alaska,US,64.6813,-163.406
-AK429,Whittier,,Alaska,US,60.773,-148.684
-AK430,Willow,,Alaska,US,61.7472,-150.037
-AK431,Wiseman,,Alaska,US,67.41,-150.107
-AK432,Womens Bay,,Alaska,US,57.7099,-152.586
-AK433,Woody Island,,Alaska,US,57.78,-152.355
-AK434,Wrangell,Shtax’héen,Alaska,US,56.4708,-132.377
-AK435,Yakutat,Yaakwdáat,Alaska,US,59.5469,-139.727
-AK464,Ziegler Cove State Marine Park,,Alaska,US,60.8381,-148.3205
+id,name,alt_name,region,country,latitude,longitude,km_distance_to_ocean
+AK1,Afognak,Agw’aneq,Alaska,US,58.0078,-152.768,0.2
+AK2,Akhiok,Kasukuak,Alaska,US,56.9455,-154.17,0.1
+AK3,Akiachak,Akiacuar,Alaska,US,60.9094,-161.431,89.7
+AK4,Akiak,Akiaq,Alaska,US,60.9122,-161.214,97.4
+AK5,Akutan,Achan-ingiiga,Alaska,US,54.1385,-165.778,0.6
+AK6,Alakanuk,Alarneq,Alaska,US,62.6889,-164.615,8.7
+AK7,Alatna,Alaasuq,Alaska,US,66.5542,-152.7019,334.8
+AK8,Aleknagik,Alaqnaqiq,Alaska,US,59.273,-158.618,15.4
+AK9,Aleut Village,,Alaska,US,58.0171,-152.761,0.0
+AK10,Alexander Creek,,Alaska,US,61.4171,-150.593,6.4
+AK11,Allakaket,Aalaa Kkaakk’et,Alaska,US,66.5656,-152.646,337.2
+AK12,Ambler,Ivisaappaat,Alaska,US,67.0861,-157.851,116.5
+AK13,Anaktuvuk Pass,Anaqtuuvak / Naqsraq,Alaska,US,68.1433,-151.736,244.1
+AK14,Anchor Point,,Alaska,US,59.7766,-151.831,2.0
+AK15,Anchorage,Dgheyaytnu,Alaska,US,61.1817,-149.993,2.1
+AK16,Anderson,,Alaska,US,64.3441,-149.187,315.5
+AK18,Angoon,Aangóon,Alaska,US,57.5033,-134.584,0.0
+AK19,Aniak,Anyaraq,Alaska,US,61.5783,-159.522,213.7
+AK20,Annette,,Alaska,US,55.063,-131.541,0.1
+AK21,Anvik,Gitr’ingith Chagg,Alaska,US,62.6561,-160.207,105.8
+AK22,Arctic Village,Vashrąįį K'ǫǫ,Alaska,US,68.1269,-145.538,203.3
+AK23,Atka,Atx̂ax̂,Alaska,US,52.191,-174.189,0.1
+AK24,Atmautluak,Atmaulluaq,Alaska,US,60.8641,-162.2723,64.0
+AK25,Atqasuk,,Alaska,US,70.4694,-157.396,46.0
+AK26,Attu,,Alaska,US,52.9365,173.24,0.4
+AK27,Auke Bay,,Alaska,US,58.383,-134.657,0.0
+AK28,Ayakulik,,Alaska,US,57.2113,-154.546,0.3
+AK29,Baranof Warm Springs,,Alaska,US,57.0895,-134.8337,0.2
+AK30,Bartlett Cove,,Alaska,US,58.45,-135.916,0.9
+AK31,Beaver,Ts'aahudaaneekk'onh Denh,Alaska,US,66.3594,-147.396,410.1
+AK444,Beecher Pass State Marine Park,,Alaska,US,56.6003,-133.0267,0.1
+AK32,Belkofski,Taxtamax̂,Alaska,US,55.0905,-162.034,0.3
+AK33,Bell Island Hot Springs,,Alaska,US,55.933,-131.566,0.8
+AK35,Bessie No. 5 Dredge,,Alaska,US,64.5502,-165.151,8.7
+AK36,Bethel,Mamterilleq,Alaska,US,60.7922,-161.756,68.9
+AK37,Bettles,Kk’odlel T’odegheelenh Denh,Alaska,US,66.9185,-151.5162,379.1
+AK445,Bettles Bay State Marine Park,,Alaska,US,60.9597,-148.3184,0.0
+AK38,Big Delta,,Alaska,US,64.1525,-145.842,335.1
+AK39,Big Lake,,Alaska,US,61.5378,-149.824,10.2
+AK40,Bill Moore's Slough,,Alaska,US,62.9504,-163.7777,15.3
+AK41,Biorka,,Alaska,US,53.831,-166.208,0.1
+AK42,Birch Creek,Łiteet'aii,Alaska,US,66.2687,-145.824,409.6
+AK43,Birchwood,,Alaska,US,61.4081,-149.481,2.4
+AK44,Bird Point,,Alaska,US,60.9311,-149.358,0.3
+AK45,Bodenburg Butte,,Alaska,US,61.5495,-149.047,7.7
+AK46,Boswell Bay,,Alaska,US,60.4001,-146.133,0.2
+AK47,Brevig Mission,Sitaisaq,Alaska,US,65.3347,-166.489,0.3
+AK48,Buckland,Kaŋiq,Alaska,US,65.9797,-161.123,13.7
+AK49,Candle,,Alaska,US,65.9133,-161.924,5.1
+AK50,Cantwell,Yidateni Na’,Alaska,US,63.3917,-148.951,210.0
+AK51,Cape Lisburne,,Alaska,US,68.8678,-166.193,1.4
+AK52,Cape Pole,,Alaska,US,55.965,-133.798,0.3
+AK53,Cape Yakataga,,Alaska,US,60.0652,-142.428,0.2
+AK54,Central,,Alaska,US,65.5724,-144.803,473.1
+AK55,Chakaktolik,,Alaska,US,61.7711,-163.625,93.7
+AK56,Chakwaktolik,,Alaska,US,61.2291,-163.754,41.7
+AK57,Chalkyitsik,Jałgiitsik,Alaska,US,66.6544,-143.722,343.8
+AK58,Chaniliut,,Alaska,US,63.0332,-163.417,1.1
+AK60,Chatham,,Alaska,US,57.514,-134.924,0.3
+AK61,Chefornak,Cevvʼarneq / Caputnguaq,Alaska,US,60.1607,-164.271,10.3
+AK62,Chena Hot Springs,,Alaska,US,65.053,-146.056,425.7
+AK63,Chenega Bay,Caniqaq,Alaska,US,60.0746,-148.003,0.3
+AK64,Chevak,Cevʼaq,Alaska,US,61.5278,-165.586,9.9
+AK65,Chickaloon,Nay’dini’aa Na’,Alaska,US,61.7967,-148.463,49.1
+AK66,Chicken,,Alaska,US,64.0733,-141.936,397.6
+AK67,Chignik,Cirniq,Alaska,US,56.2953,-158.402,0.1
+AK68,Chignik Lagoon,Nanwarnaq,Alaska,US,56.3104,-158.5361,0.3
+AK69,Chignik Lake,Igyaraq,Alaska,US,56.2552,-158.7696,5.9
+AK446,Chilkat River Critical Habitat Area,,Alaska,US,59.373,-135.8596,12.8
+AK70,Chiniak,,Alaska,US,57.617,-152.2166,0.4
+AK71,Chisana,,Alaska,US,62.0671,-142.049,218.2
+AK72,Chistochina,Tsiis Tl’edze’ Caegge,Alaska,US,62.565,-144.665,182.0
+AK73,Chitina,Tsedi Na',Alaska,US,61.5158,-144.437,107.0
+AK74,Christian,,Alaska,US,67.3673,-145.2,286.2
+AK75,Chuathbaluk,Curarpalek,Alaska,US,61.5726,-159.235,224.3
+AK447,Chugach National Forest Municipal Watershed,,Alaska,US,60.5195,-145.7223,2.9
+AK76,Chuloonawick,,Alaska,US,62.8961,-163.894,23.6
+AK77,Circle,Danzhit Khànląįį,Alaska,US,65.8255,-144.061,436.8
+AK78,Circle Hot Springs,,Alaska,US,65.4833,-144.634,480.4
+AK79,Clam Gulch,,Alaska,US,60.2311,-151.394,0.8
+AK80,Clark's Point,Saguyaq,Alaska,US,58.8441,-158.551,0.3
+AK81,Clear,,Alaska,US,64.3332,-149.167,314.3
+AK82,Clover Pass,,Alaska,US,55.472,-131.791,0.4
+AK83,Coffman Cove,,Alaska,US,56.0119,-132.8296,0.3
+AK84,Cohoe,,Alaska,US,60.3671,-151.3,2.0
+AK85,Cold Bay,,Alaska,US,55.1858,-162.721,2.2
+AK86,College,,Alaska,US,64.8582,-147.808,380.6
+AK87,Cooper Landing,,Alaska,US,60.4906,-149.833,46.8
+AK88,Copper Center,Tl’aticae’e,Alaska,US,61.955,-145.305,106.3
+AK89,Cordova,,Alaska,US,60.5428,-145.757,0.4
+AK90,Council,,Alaska,US,64.895,-163.676,31.0
+AK91,Craig,Sháan Séet,Alaska,US,55.4764,-133.148,0.2
+AK92,Crooked Creek,Qipcarpak,Alaska,US,61.87,-158.111,239.4
+AK448,Dall Bay State Marine Park,,Alaska,US,55.1559,-131.749,0.1
+AK93,Deadhorse,,Alaska,US,70.2097,-148.418,10.1
+AK449,Decision Point State Marine Park,,Alaska,US,60.8016,-148.464,0.5
+AK94,Deering,Ipnatchiaq,Alaska,US,66.0755,-162.717,0.2
+AK95,Delta Junction,,Alaska,US,64.0377,-145.732,324.6
+AK96,Dillingham,Curyung,Alaska,US,59.0397,-158.457,0.3
+AK97,Diomede,Iŋaliq,Alaska,US,65.7648,-168.911,0.5
+AK98,Dot Lake,Kelt’aaddh Menn’,Alaska,US,63.663,-144.049,305.9
+AK99,Douglas,,Alaska,US,58.2762,-134.392,0.0
+AK100,Dry Creek,,Alaska,US,63.7,-144.567,300.6
+AK101,Dutch Harbor,,Alaska,US,53.891,-166.535,0.1
+AK102,Eagle,Tthee T'äwdlenn,Alaska,US,64.788,-141.2,483.1
+AK103,Eagle River,,Alaska,US,61.3221,-149.567,8.4
+AK104,Eagle Village,,Alaska,US,64.7805,-141.114,484.8
+AK441,Eareckson Air Station,,Alaska,US,52.7122,174.1136,0.4
+AK105,Edna Bay,,Alaska,US,55.9489,-133.662,0.0
+AK106,Eek,Ekvicuaq,Alaska,US,60.2189,-162.024,11.7
+AK107,Egavik,,Alaska,US,64.0332,-160.917,0.5
+AK108,Egegik,Igyagiiq,Alaska,US,58.2155,-157.376,0.2
+AK109,Egorkovskoi,,Alaska,US,53.564,-168.0,0.1
+AK442,Eielson Air Force Base,,Alaska,US,64.6656,-147.1014,368.1
+AK110,Eklutna,Idlughet,Alaska,US,61.458,-149.362,1.5
+AK111,Ekuk,,Alaska,US,58.804,-158.541,1.1
+AK112,Ekwok,Iquaq,Alaska,US,59.3497,-157.475,47.6
+AK113,Elephant Point,,Alaska,US,66.2673,-161.333,0.8
+AK114,Elfin Cove,,Alaska,US,58.1944,-136.343,0.1
+AK115,Elim,Neviarcaurluq,Alaska,US,64.6175,-162.26,0.3
+AK116,Ellamar,,Alaska,US,60.8961,-146.708,0.1
+AK117,Emmonak,Imangaq,Alaska,US,62.7778,-164.523,11.5
+AK450,Ernie Haugen Public Use Area,,Alaska,US,56.5421,-132.6616,0.4
+AK119,Eska,,Alaska,US,61.7381,-148.906,29.4
+AK120,Ester,,Alaska,US,64.8472,-148.014,377.5
+AK122,Excursion Inlet,,Alaska,US,58.417,-135.441,0.2
+AK123,Eyak,Igya’aq,Alaska,US,60.5652,-145.7,2.0
+AK124,Fairbanks,,Alaska,US,64.8378,-147.716,379.3
+AK125,False Pass,Isanax̂,Alaska,US,54.8548,-163.407,0.1
+AK126,Ferry,,Alaska,US,64.0172,-149.117,279.1
+AK127,Fish Village,,Alaska,US,62.5212,-163.847,45.2
+AK128,Flat,,Alaska,US,62.4536,-158.007,197.3
+AK129,Fort Glenn,,Alaska,US,53.3956,-167.881,2.4
+AK440,Fort Greely,,Alaska,US,63.9731,-145.7181,318.0
+AK438,Fort Wainwright,,Alaska,US,64.8278,-147.6429,379.0
+AK130,Fort Yukon,Gwichyaa Zheh,Alaska,US,66.5647,-145.274,375.4
+AK131,Fox,,Alaska,US,64.958,-147.618,393.4
+AK451,Funter Bay State Marine Park,,Alaska,US,58.2505,-134.9227,0.2
+AK132,Gakona,Ggax Kuna’,Alaska,US,62.3019,-145.302,141.1
+AK133,Galena,Notaalee Denh,Alaska,US,64.7333,-156.927,183.8
+AK134,Gambell,Sivuqaq,Alaska,US,63.7797,-171.741,0.2
+AK135,Georgetown,,Alaska,US,61.9085,-157.787,247.2
+AK136,Girdwood,,Alaska,US,60.9421,-149.167,0.5
+AK137,Glennallen,,Alaska,US,62.1092,-145.546,116.4
+AK452,Goldstream Public Use Area,,Alaska,US,64.93,-147.7653,388.9
+AK138,Golovin,Cingik / Siŋik,Alaska,US,64.5433,-163.029,0.2
+AK139,Goodnews Bay,Mamterat,Alaska,US,59.1186,-161.589,0.2
+AK140,Grayling,Sixno' Xidakagg,Alaska,US,62.9062,-160.077,85.5
+AK141,Gulkana,C'uul C'ena',Alaska,US,62.2714,-145.382,136.4
+AK142,Gustavus,,Alaska,US,58.4125,-135.738,1.1
+AK143,Haines,Deishú,Alaska,US,59.2358,-135.445,0.5
+AK145,Haycock,,Alaska,US,65.2172,-161.167,29.2
+AK146,Healy,,Alaska,US,63.8578,-148.966,261.8
+AK147,Healy Lake,Mendees Cheeg,Alaska,US,63.9441,-144.755,324.1
+AK148,Highland Park,,Alaska,US,64.7582,-147.371,374.5
+AK149,Holikachuk,,Alaska,US,62.9112,-159.517,105.1
+AK150,Hollis,,Alaska,US,55.4879,-132.663,0.1
+AK151,Holy Cross,Ingirraller / Deloy Chet,Alaska,US,62.1994,-159.771,161.5
+AK152,Homer,,Alaska,US,59.6425,-151.548,0.6
+AK153,Hoonah,Xunaa / Gaaw Yat’aḵ Aan,Alaska,US,58.11,-135.444,0.2
+AK154,Hooper Bay,Naparyaarmiut,Alaska,US,61.5311,-166.097,0.7
+AK155,Hope,,Alaska,US,60.9203,-149.64,0.6
+AK156,Houston,,Alaska,US,61.6302,-149.818,18.4
+AK157,Hughes,Hut’odlee Kkaakk’et,Alaska,US,66.0488,-154.255,272.0
+AK158,Huslia,Ts’aateyhdenaadekk’onh Denh,Alaska,US,65.6986,-156.4,190.2
+AK159,Hydaburg,Higdáa G̱ándlaay,Alaska,US,55.208,-132.827,0.0
+AK160,Hyder,,Alaska,US,55.9169,-130.025,0.5
+AK161,Iditarod,,Alaska,US,62.5448,-158.094,187.5
+AK162,Igiugig,Igyaraq,Alaska,US,59.3278,-155.895,62.6
+AK163,Ikatan,,Alaska,US,54.75,-163.308,0.4
+AK164,Iliamna,Illiamna,Alaska,US,59.7536,-154.817,57.0
+AK165,Inakpuk,,Alaska,US,59.5331,-157.15,55.9
+AK166,Indian,,Alaska,US,60.9881,-149.513,0.3
+AK167,Indian River,,Alaska,US,62.6672,-144.433,197.8
+AK168,Ingrihak,,Alaska,US,61.7561,-162.0,134.1
+AK169,Ivanof Bay,,Alaska,US,55.8996,-159.507,0.5
+AK453,Joe Mace Island State Marine Park,,Alaska,US,56.3473,-133.635,0.0
+AK170,Joe Ward Camp,,Alaska,US,66.8673,-143.699,320.8
+AK439,Joint Base Elmendorf-Richardson,,Alaska,US,61.2514,-149.8064,3.6
+AK171,Jonesville,,Alaska,US,61.7311,-148.933,28.0
+AK172,Juneau,Dzánti K'ihéeni,Alaska,US,58.3019,-134.42,0.4
+AK173,Kachemak,,Alaska,US,59.6488,-151.451,0.3
+AK174,Kake,Ḵéex̱ʼ,Alaska,US,56.9758,-133.947,0.2
+AK176,Kaktovik,Qaaktuġvik,Alaska,US,70.1319,-143.624,0.3
+AK177,Kalifornsky,Unhghenesditnu,Alaska,US,60.4412,-151.198,4.8
+AK179,Kaltag,Ggaał Doh,Alaska,US,64.3272,-158.722,104.8
+AK180,Kanakanak,,Alaska,US,59.0031,-158.533,0.1
+AK443,Kantishna,,Alaska,US,63.5253,-150.9581,237.2
+AK454,Kanuti Hot Springs Area Of Critical Environmental Concern,,Alaska,US,66.3427,-150.8468,419.4
+AK181,Karluk,Kal’ut,Alaska,US,57.5719,-154.455,0.3
+AK182,Kasaan,Gasa'áan,Alaska,US,55.5389,-132.401,0.0
+AK183,Kashega,,Alaska,US,53.467,-167.16,0.1
+AK184,Kashegelok,,Alaska,US,60.8331,-157.833,193.1
+AK185,Kasigluk,Kassigluq,Alaska,US,60.8955,-162.521,52.2
+AK186,Kasilof,,Alaska,US,60.3375,-151.274,5.4
+AK187,Kathakne,,Alaska,US,62.9692,-141.832,310.7
+AK188,Kenai,Shk'ituk't,Alaska,US,60.5544,-151.258,0.5
+AK189,Kenny Lake,,Alaska,US,61.7379,-144.945,99.2
+AK190,Kepangalook,,Alaska,US,60.8501,-161.617,78.4
+AK191,Ketchikan,Kichx̱áan,Alaska,US,55.3422,-131.646,0.2
+AK192,Kiana,Katyaaq,Alaska,US,66.975,-160.423,37.6
+AK193,Kinegnak,,Alaska,US,58.8331,-161.667,1.5
+AK194,King Cove,Agdaaĝux̂,Alaska,US,55.0629,-162.31,0.3
+AK195,King Island,Ugiuvak,Alaska,US,64.9694,-168.065,1.2
+AK196,King Salmon,,Alaska,US,58.6883,-156.661,15.0
+AK197,Kipnuk,Qipnek,Alaska,US,59.9389,-164.041,1.6
+AK198,Kivalina,Kivaliñiq,Alaska,US,67.7269,-164.533,0.0
+AK199,Kiwalik,,Alaska,US,66.0333,-161.833,0.4
+AK200,Klawock,Lawaak,Alaska,US,55.5522,-133.096,0.3
+AK201,Klery Creek,,Alaska,US,67.1793,-160.4,53.0
+AK202,Klukwan,Tlákw.aan,Alaska,US,59.3991,-135.894,15.0
+AK203,Knik,,Alaska,US,61.4578,-149.729,0.3
+AK204,Kobuk,Laugviik,Alaska,US,66.9072,-156.881,151.4
+AK205,Kodiak,Sun'aq,Alaska,US,57.79,-152.407,0.3
+AK206,Kokhanok,Qarr’unaq,Alaska,US,59.4426,-154.761,35.9
+AK207,Kokrines,Łoyh Denlekk’es Denh,Alaska,US,64.9332,-154.7,289.8
+AK208,Koliganek,Qalirneq,Alaska,US,59.7286,-157.284,79.0
+AK209,Kongiganak,Kangirnaq,Alaska,US,59.9647,-162.877,4.2
+AK210,Kotlik,Qerrulliik,Alaska,US,63.0341,-163.553,4.2
+AK211,Kotzebue,Qikiqtaġruk,Alaska,US,66.8983,-162.597,0.3
+AK212,Koyuk,Kuuyuk,Alaska,US,64.9319,-161.157,0.3
+AK213,Koyukuk,Meneelghaadze’ T’oh,Alaska,US,64.8802,-157.701,147.7
+AK214,Kupreanof,,Alaska,US,56.8153,-133.006,0.1
+AK215,Kustatan,Qezdeghnen,Alaska,US,60.7171,-151.75,0.3
+AK216,Kvichak,,Alaska,US,58.9671,-156.933,0.3
+AK217,Kwethluk,Kuiggluk,Alaska,US,60.8122,-161.436,81.0
+AK218,Kwigillingok,Kuigilnguq,Alaska,US,59.8644,-163.134,1.3
+AK219,Kwiguk,,Alaska,US,62.7683,-164.5067,12.5
+AK220,Lake Minchumina,Menchuh Mene’,Alaska,US,63.8828,-152.312,295.6
+AK455,Lake Todatonten Pingos Research Natural Area,,Alaska,US,66.1055,-152.938,329.7
+AK221,Larsen Bay,Uyaqsaq,Alaska,US,57.54,-153.979,0.2
+AK222,Last Tetlin Village,,Alaska,US,63.0332,-142.616,286.6
+AK223,Latouche,,Alaska,US,60.0511,-147.9,0.3
+AK225,Lena Beach,,Alaska,US,58.393,-134.746,0.5
+AK226,Levelock,Liivlek,Alaska,US,59.115,-156.857,6.9
+AK227,Libbyville,,Alaska,US,58.7781,-157.056,0.3
+AK228,Lime Village,Hekdichen Hdakaq',Alaska,US,61.3564,-155.436,177.4
+AK229,Livengood,,Alaska,US,65.5244,-148.545,448.7
+AK230,Loring,,Alaska,US,55.603,-131.632,0.2
+AK231,Lower Kalskag,Qalqaq,Alaska,US,61.5122,-160.358,178.2
+AK232,Lower Tonsina,Kentsii Cae'e,Alaska,US,61.655,-144.659,104.9
+AK233,Lucky Shot Landing,,Alaska,US,61.7751,-149.408,28.4
+AK234,Manley Hot Springs,Too Naaleł Denh,Alaska,US,65.0011,-150.634,393.9
+AK235,Manokotak,Manuquutaq,Alaska,US,58.9796,-159.053,18.8
+AK236,Mansfield Village,Dihthâad,Alaska,US,63.4672,-143.433,300.4
+AK237,Marshall,Masserculleq,Alaska,US,61.8778,-162.081,140.8
+AK238,Marys Igloo,,Alaska,US,65.1478,-165.063,45.4
+AK239,Matanuska,,Alaska,US,61.5421,-149.229,3.4
+AK240,McCarthy,,Alaska,US,61.4333,-142.922,149.2
+AK241,McGrath,Tochak’,Alaska,US,62.9564,-155.596,273.8
+AK242,McKinley Park Airport,,Alaska,US,63.7331,-148.9111,248.2
+AK243,Meakerville,,Alaska,US,60.5421,-145.008,8.6
+AK244,Medfra,,Alaska,US,63.1067,-154.714,288.1
+AK245,Mekoryuk,Mikuryar,Alaska,US,60.388,-166.185,0.0
+AK246,Mendeltna,,Alaska,US,62.0487,-146.5386,101.4
+AK247,Mentasta Lake,Mendaesde,Alaska,US,62.9212,-143.792,239.3
+AK248,Metlakatla,Maxłakxaała,Alaska,US,55.1292,-131.572,0.2
+AK249,Meyers Chuck,,Alaska,US,55.7408,-132.256,0.0
+AK250,Minto,,Alaska,US,65.1496,-149.3504,405.2
+AK251,Moose Pass,,Alaska,US,60.4876,-149.367,40.6
+AK252,Morzhovoi,,Alaska,US,54.91,-163.303,0.4
+AK253,Moses Point,,Alaska,US,64.7002,-162.033,0.1
+AK254,Mountain Village,Asaacaryaraq,Alaska,US,62.0884,-163.72,73.9
+AK256,Nabesna,Naambia Niign Daacheeg,Alaska,US,62.3719,-143.009,222.1
+AK257,Nakeen,,Alaska,US,58.9361,-157.038,0.1
+AK258,Naknek,Nakniq,Alaska,US,58.7283,-157.014,0.1
+AK259,Nanwalek,English Bay,Alaska,US,59.354,-151.916,0.6
+AK261,Napakiak,Naparyarraq,Alaska,US,60.6967,-161.952,54.4
+AK262,Napaimute,,Alaska,US,61.54,-158.674,245.1
+AK263,Napaskiak,Napaskiaq,Alaska,US,60.708,-161.766,60.7
+AK264,Nash Harbor,,Alaska,US,60.2041,-166.939,0.1
+AK265,Nelchina,,Alaska,US,61.996,-146.8203,92.8
+AK266,Nelson Lagoon,Niilsanam Alĝuudaa,Alaska,US,56.0012,-161.201,0.2
+AK267,Nenana,Toghotili,Alaska,US,64.5638,-149.093,340.1
+AK268,New Knockhock,,Alaska,US,62.1291,-164.894,28.0
+AK269,New Stuyahok,Cetuyaraq,Alaska,US,59.4528,-157.312,51.2
+AK270,Newhalen,Nuuriileng,Alaska,US,59.72,-154.897,57.6
+AK271,Newtok,Niugtaq,Alaska,US,60.9427,-164.629,1.9
+AK272,Nightmute,Negtemiut,Alaska,US,60.4794,-164.724,8.2
+AK273,Nikiski,,Alaska,US,60.6394,-151.334,1.3
+AK274,Nikolaevsk,,Alaska,US,59.8109,-151.623,11.3
+AK275,Nikolai,Nikolai,Alaska,US,63.0133,-154.375,268.8
+AK276,Nikolski,Chalukax̂,Alaska,US,52.938,-168.868,0.3
+AK277,Nilikluguk,,Alaska,US,60.6501,-165.15,0.3
+AK278,Ninilchik,,Alaska,US,60.0514,-151.669,0.3
+AK279,Noatak,Nuataam Kuuŋa,Alaska,US,67.5711,-162.965,42.7
+AK280,Nome,Sitŋasuaq,Alaska,US,64.5107,-165.4447,1.1
+AK281,Nondalton,Nundaltin,Alaska,US,59.9736,-154.846,73.3
+AK282,Noorvik,Nuurvik,Alaska,US,66.8383,-161.033,20.5
+AK283,North Pole,,Alaska,US,64.7511,-147.349,374.0
+AK284,Northway,K’ehtthiign,Alaska,US,62.9616,-141.937,306.1
+AK285,Northway Indian Village,,Alaska,US,62.9832,-141.949,307.2
+AK286,Northway Junction,,Alaska,US,63.0173,-141.792,315.7
+AK287,Nuiqsut,Nuiqsat,Alaska,US,70.2175,-150.976,17.0
+AK288,Nulato,Noolaaghe Doh,Alaska,US,64.7194,-158.103,127.8
+AK289,Nunam Iqua,Sheldon Point,Alaska,US,62.5336,-164.841,0.0
+AK290,Nunapitchuk,Nunapicuar,Alaska,US,60.8969,-162.459,55.4
+AK291,Nyac,,Alaska,US,61.0061,-159.946,155.1
+AK292,Ohogamiut,Urr'agmiut,Alaska,US,61.5677,-161.864,123.3
+AK293,Old Harbor,Nuniaq,Alaska,US,57.2028,-153.304,0.0
+AK294,Old Minto,Menhti Xwghotthit,Alaska,US,64.8882,-149.182,376.1
+AK456,Oliver Inlet State Marine Park,,Alaska,US,58.1015,-134.3127,0.6
+AK295,Ophir,,Alaska,US,63.1447,-156.519,222.8
+AK296,Oscarville,Kuiggayagaq,Alaska,US,60.7273,-161.79,61.8
+AK297,Osviak,,Alaska,US,58.8171,-161.3,5.1
+AK298,Ouzinkie,Uusenkaa,Alaska,US,57.9236,-152.496,0.3
+AK299,Paimiut,Paimute,Alaska,US,61.6971,-165.83,1.0
+AK300,Palmer,,Alaska,US,61.5997,-149.113,11.0
+AK301,Pastolik,,Alaska,US,62.9972,-163.304,0.8
+AK302,Pauloff Harbor,,Alaska,US,54.4589,-162.7,0.1
+AK303,Paxson,,Alaska,US,63.033,-145.4979,216.5
+AK304,Pedro Bay,,Alaska,US,59.7914,-154.098,28.1
+AK305,Pelican,K'udeis'x̱'e,Alaska,US,57.9608,-136.227,0.2
+AK306,Pennock Island,,Alaska,US,55.328,-131.628,0.0
+AK307,Perryville,Perry-q,Alaska,US,55.9119,-159.166,0.8
+AK308,Petersburg,Séet Ká,Alaska,US,56.8125,-132.955,0.4
+AK309,Petersville,,Alaska,US,62.373,-150.7332,113.3
+AK310,Pile Bay Village,,Alaska,US,59.7789,-153.8819,17.8
+AK311,Pilot Point,Agisaq,Alaska,US,57.5641,-157.579,0.1
+AK312,Pilot Station,Tuutalgaq,Alaska,US,61.9389,-162.875,119.1
+AK313,Pitkas Point,Negeqliim Painga,Alaska,US,62.0328,-163.288,95.4
+AK314,Platinum,Arviiq,Alaska,US,59.013,-161.816,0.5
+AK315,Point Baker,,Alaska,US,56.3528,-133.621,0.0
+AK316,Point Hope,Tikiġaq,Alaska,US,68.3477,-166.808,0.5
+AK317,Point Lay,Kali,Alaska,US,69.7574,-163.051,0.0
+AK318,Poorman,,Alaska,US,64.0991,-155.544,254.6
+AK319,Port Alexander,,Alaska,US,56.2497,-134.644,0.2
+AK320,Port Alsworth,,Alaska,US,60.2025,-154.313,65.3
+AK321,Port Ashton,,Alaska,US,60.0581,-148.05,0.1
+AK322,Port Graham,Paluwik,Alaska,US,59.3514,-151.83,0.1
+AK323,Port Heiden,Masrriq,Alaska,US,56.9566,-158.645,2.6
+AK324,Port Lions,Masiqsirraq,Alaska,US,57.8675,-152.882,0.1
+AK325,Port Mackenzie,,Alaska,US,61.2686,-149.9202,0.2
+AK326,Port Moller,,Alaska,US,55.99,-160.577,0.2
+AK327,Port Protection,,Alaska,US,56.3127,-133.602,0.2
+AK328,Portage,,Alaska,US,60.8381,-148.979,0.6
+AK329,Portage Creek,,Alaska,US,58.9006,-157.714,17.6
+AK330,Portlock,,Alaska,US,59.2144,-151.7461,0.1
+AK331,Prudhoe Bay,,Alaska,US,70.2366,-148.38,7.3
+AK332,Quinhagak,Kuinerraq,Alaska,US,59.7489,-161.916,0.9
+AK333,Rainbow,,Alaska,US,61.0041,-149.642,0.7
+AK334,Rampart,Dleł Taaneets,Alaska,US,65.5049,-150.17,446.6
+AK335,Red Devil,,Alaska,US,61.7611,-157.313,276.2
+AK336,Refuge Cove,,Alaska,US,55.407,-131.741,0.5
+AK337,Ruby,Tl'aa'ologhe,Alaska,US,64.7394,-155.487,252.4
+AK338,Russian Mission,Iqugmiut,Alaska,US,61.7856,-161.325,160.7
+AK457,Safety Cove State Marine Park,,Alaska,US,59.9819,-149.2235,0.1
+AK339,Saint George,Anĝaaxchalux̂,Alaska,US,56.603,-169.545,0.3
+AK340,Saint Mary's,Negeqliq,Alaska,US,62.053,-163.166,99.4
+AK341,Saint Michael,Taciq,Alaska,US,63.478,-162.039,0.0
+AK342,Saint Paul,Tanax̂ Amix̂,Alaska,US,57.1221,-170.276,0.3
+AK343,Salamatof,,Alaska,US,60.5878,-151.326,0.6
+AK344,Salcha,Soł Chaget,Alaska,US,64.5288,-146.899,356.7
+AK345,Salt Chuck,,Alaska,US,55.628,-132.552,2.8
+AK346,Sanak,,Alaska,US,54.4831,-162.814,0.1
+AK347,Sand Point,,Alaska,US,55.3397,-160.497,0.1
+AK458,Sandspit Point State Marine Park,,Alaska,US,59.9378,-149.318,0.1
+AK348,Savonoski,,Alaska,US,58.7171,-156.867,3.0
+AK349,Savoonga,Sivunga,Alaska,US,63.6904,-170.481,0.7
+AK350,Saxman,,Alaska,US,55.3183,-131.596,0.3
+AK351,Scammon Bay,Marayaarmiut,Alaska,US,61.8428,-165.582,0.5
+AK352,Selawik,Siiḷivik / Akuliġaq,Alaska,US,66.6039,-160.007,10.7
+AK353,Seldovia,Angagkitaqnuuq,Alaska,US,59.438,-151.711,0.3
+AK354,Seward,Qutalleq,Alaska,US,60.1043,-149.442,0.5
+AK355,Shageluk,Edixi,Alaska,US,62.6822,-159.562,121.5
+AK356,Shaktoolik,Saktuliq,Alaska,US,64.35,-161.183,0.5
+AK357,Shemya Station,,Alaska,US,52.7246,174.112,0.9
+AK358,Shishmaref,Qigiqtaq,Alaska,US,66.2567,-166.072,0.5
+AK359,Shungnak,Isiŋnaq / Nuurviuraq,Alaska,US,66.888,-157.136,140.0
+AK360,Sitka,Sheet'ká,Alaska,US,57.053,-135.33,0.4
+AK361,Skagway,,Alaska,US,59.4583,-135.314,0.9
+AK362,Skwentna,,Alaska,US,61.9649,-151.158,74.2
+AK363,Slana,Stl’aa Caegge,Alaska,US,62.707,-143.9697,214.5
+AK365,Sleetmute,Cellitemiut,Alaska,US,61.7025,-157.17,274.2
+AK366,Soldotna,,Alaska,US,60.4878,-151.058,11.4
+AK367,Solomon,,Alaska,US,64.5608,-164.439,1.2
+AK368,South Naknek,Qinuyang,Alaska,US,58.7155,-156.998,0.5
+AK459,South Todatonten Summit Research Natural Area,,Alaska,US,66.0506,-152.881,333.3
+AK369,Spenard,,Alaska,US,61.1881,-149.917,2.4
+AK370,Squaw Harbor,,Alaska,US,55.2433,-160.553,0.3
+AK371,St. Mary's,,Alaska,US,62.0331,-163.25,97.0
+AK460,Stan Price State Wildlife Sanctuary,,Alaska,US,57.9051,-134.275,0.5
+AK372,Stebbins,Tapraq,Alaska,US,63.5222,-162.288,0.2
+AK373,Sterling,,Alaska,US,60.5381,-150.758,25.8
+AK374,Stevens Village,Denyeet,Alaska,US,66.0063,-149.091,465.2
+AK375,Stony River,Gidighuyghatno’ Xidochagg Qay / K'qizaghetnu,Alaska,US,61.7831,-156.588,254.8
+AK376,Summit,,Alaska,US,63.3292,-149.119,202.4
+AK461,Sunny Cove State Marine Park,,Alaska,US,59.9024,-149.3453,0.4
+AK377,Sunrise,,Alaska,US,60.8921,-149.425,0.8
+AK378,Suntrana,,Alaska,US,63.8582,-148.846,262.4
+AK379,Susitna Station,,Alaska,US,61.5432,-150.5162,20.1
+AK380,Sutton,,Alaska,US,61.7114,-148.894,27.0
+AK381,Takotna,Tochotno’,Alaska,US,62.9886,-156.064,250.5
+AK462,Taku Harbor State Marine Park,,Alaska,US,58.0622,-134.0187,0.1
+AK382,Talkeetna,K'dalkitnu,Alaska,US,62.3239,-150.109,96.3
+AK383,Tanacross,Taats’altęy,Alaska,US,63.378,-143.356,293.9
+AK384,Tanana,Hohudodetlaatl Denh,Alaska,US,65.1719,-152.079,397.4
+AK386,Tatitlek,Taatiilaaq,Alaska,US,60.8647,-146.679,0.3
+AK387,Tazlina,Tezdlen Na’,Alaska,US,62.0305,-145.416,111.0
+AK388,Tee Harbor,,Alaska,US,58.41,-134.757,0.4
+AK389,Telida,Tilayadi,Alaska,US,63.3833,-153.267,265.2
+AK390,Teller,Tala,Alaska,US,65.2636,-166.361,0.1
+AK392,Tenakee Springs,Tʼanag̱eey / Tlaagoowu Aan,Alaska,US,57.7808,-135.219,0.2
+AK393,Tetlin,Teełąy,Alaska,US,63.1373,-142.5208,298.4
+AK394,Tetlin Junction,,Alaska,US,63.3172,-142.599,310.9
+AK395,Thane,,Alaska,US,58.264,-134.328,0.5
+AK396,Thorne Bay,,Alaska,US,55.7274,-132.471,0.6
+AK463,Thumb Cove State Marine Park,,Alaska,US,60.004,-149.3008,0.1
+AK397,Tin City,,Alaska,US,65.5502,-167.851,0.8
+AK398,Togiak,Tuyuryaq,Alaska,US,59.0619,-160.376,0.3
+AK399,Tok,,Alaska,US,63.3366,-142.985,300.6
+AK400,Tokeen,,Alaska,US,55.938,-133.324,0.3
+AK401,Toksook Bay,Nunakauyaq,Alaska,US,60.5303,-165.102,0.1
+AK402,Tolovana,,Alaska,US,64.8542,-149.824,373.0
+AK403,Tonsina,,Alaska,US,61.6558,-145.175,84.0
+AK404,Tuluksak,Tuulkessaaq,Alaska,US,61.1025,-160.962,122.3
+AK405,Tuntutuliak,Tuntutuliaq,Alaska,US,60.3397,-162.669,9.1
+AK406,Tununak,Tununeq,Alaska,US,60.5855,-165.256,0.3
+AK407,Twin Hills,Ingricuar,Alaska,US,59.0792,-160.275,2.7
+AK436,Two Rivers,,Alaska,US,64.8767,-147.0384,391.5
+AK408,Tyonek,Qaggeyshlat,Alaska,US,61.0681,-151.137,0.0
+AK409,Ugashik,Ugaasaq,Alaska,US,57.513,-157.397,2.4
+AK411,Umiat,,Alaska,US,69.3674,-152.133,114.1
+AK412,Umkumiute,,Alaska,US,60.4983,-165.199,0.2
+AK413,Umnak,,Alaska,US,53.267,-168.217,1.3
+AK414,Unalakleet,Uŋalaqłiit,Alaska,US,63.873,-160.788,0.1
+AK415,Unalaska,Iluulux̂,Alaska,US,53.8733,-166.533,0.4
+AK416,Unga,Uĝnaasaqax̂,Alaska,US,55.1828,-160.506,0.3
+AK178,Upper Kalskag,Qalqaq,Alaska,US,61.5391,-160.306,182.2
+AK418,Utqiaġvik,Barrow,Alaska,US,71.2905,-156.789,0.3
+AK419,Utukakarvik,,Alaska,US,61.9611,-164.75,42.9
+AK420,Uyak,,Alaska,US,57.6256,-153.988,0.3
+AK421,Valdez,Suacit,Alaska,US,61.1369,-146.3471,0.9
+AK422,Venetie,Vįįhtąįį,Alaska,US,67.0139,-146.419,330.8
+AK423,Wainwright,Ulġuniq,Alaska,US,70.6369,-160.038,0.5
+AK424,Wales,Kiŋigin,Alaska,US,65.6097,-168.0876,0.5
+AK425,Ward Cove,,Alaska,US,55.408,-131.724,0.0
+AK426,Wasilla,,Alaska,US,61.5814,-149.439,7.8
+AK427,Whale Pass,,Alaska,US,56.1,-133.167,1.7
+AK428,White Mountain,Nasirvik,Alaska,US,64.6813,-163.406,4.2
+AK429,Whittier,,Alaska,US,60.773,-148.684,0.5
+AK430,Willow,,Alaska,US,61.7472,-150.037,35.7
+AK431,Wiseman,,Alaska,US,67.41,-150.107,323.2
+AK432,Womens Bay,,Alaska,US,57.7099,-152.586,1.1
+AK433,Woody Island,,Alaska,US,57.78,-152.355,0.4
+AK434,Wrangell,Shtax’héen,Alaska,US,56.4708,-132.377,0.6
+AK435,Yakutat,Yaakwdáat,Alaska,US,59.5469,-139.727,0.7
+AK464,Ziegler Cove State Marine Park,,Alaska,US,60.8381,-148.3205,0.2


### PR DESCRIPTION
This PR will be helpful for identifying "coastal" locations across Alaska. This information can be leveraged for selecting datasets (e.g., sea ice) or for triaging API errors where coarse gridded products don't encapsulate the finer squiggles of the AK coastline and thereby do not have data for some coastal communities.

Per discussion with @MikeDelue we've elected to not make a binary coastal-or-not flag based on some threshold distance a location must be from the ocean. There is too much nuance to navigate so we'll just report the distance in KM and let those decisions be sorted out on the client / data end of things.

For reference:

![image](https://user-images.githubusercontent.com/7774271/154101886-c10c0f52-3ec5-4746-a1c9-3eae3dacde12.png)

Coastline data to generate distances were retrieved from https://www.ngdc.noaa.gov/mgg/shorelines/ and the full resolution, Level 1 (boundary between land and ocean) data were used. 

Closes #39 