### PR TITLE
Points the update script at Varnish cache directly rather than through proxy to prevent potential proxy issues.

### DIFF
--- a/.github/workflows/refresh_api.yaml
+++ b/.github/workflows/refresh_api.yaml
@@ -10,5 +10,5 @@ jobs:
     - name: Refresh API
       uses: satak/webrequest-action@master
       with:
-        url: https://earthmaps.io/update
+        url: http://earthmaps.io:6081/update
         method: GET


### PR DESCRIPTION
This PR points the Github Action at the underlying Varnish cache and does not go through the proxy. This prevents the odd case where it cannot update the files due to the proxy having an issue with waiting for the backend server.