### PR TITLE
Remove AK370 from the list of AK communities

### DIFF
--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -398,7 +398,6 @@ AK367,Solomon,,Alaska,US,64.5608,-164.439,1.2
 AK368,South Naknek,Qinuyang,Alaska,US,58.7155,-156.998,0.5
 AK459,South Todatonten Summit Research Natural Area,,Alaska,US,66.0506,-152.881,333.3
 AK369,Spenard,,Alaska,US,61.1881,-149.917,2.4
-AK370,Squaw Harbor,,Alaska,US,55.2433,-160.553,0.3
 AK371,St. Mary's,,Alaska,US,62.0331,-163.25,97.0
 AK460,Stan Price State Wildlife Sanctuary,,Alaska,US,57.9051,-134.275,0.5
 AK372,Stebbins,Tapraq,Alaska,US,63.5222,-162.288,0.2


### PR DESCRIPTION
This tiny PR removes a single record from the list of Alaska communities.
The `AK370` record was not provided a new place name by the USGS and we have nearby communities to represent this geographic area.

Closes #14 