### PR TITLE
remove St. Mary's and St. George in favor of existing full "Saint" names

### DIFF
--- a/vector_data/point/alaska_point_locations.csv
+++ b/vector_data/point/alaska_point_locations.csv
@@ -457,8 +457,6 @@ AK368,South Naknek,Qinuyang,Alaska,US,58.7155,-156.998,0.9
 AK459,South Todatonten Summit Research Natural Area,,Alaska,US,66.0506,-152.881,333.3
 AK546,South Van Horn,,Alaska,US,64.8075,-147.774,376.5
 AK369,Spenard,,Alaska,US,61.1881,-149.917,2.7
-AK547,St. George,Anĝaaxchaluxˆ,Alaska,US,56.5748,-169.6104,3.2
-AK371,St. Mary's,,Alaska,US,62.0331,-163.25,81.8
 AK460,Stan Price State Wildlife Sanctuary,,Alaska,US,57.9051,-134.275,0.1
 AK372,Stebbins,Tapraq,Alaska,US,63.5222,-162.288,0.3
 AK548,Steele Creek,,Alaska,US,64.9028,-147.5241,389.5


### PR DESCRIPTION
This PR removes St. Mary's and St. George from the `alaska_point_locations.csv` in favor of the existing full "Saint" names. Issue #117  was created to revisit the "Saint" vs "St." search problem.