### PR TITLE
Tag Canadian communities within AQI GeoTIFF BBOX with "awe" tag.

### DIFF
--- a/vector_data/point/british_columbia_point_locations.csv
+++ b/vector_data/point/british_columbia_point_locations.csv
@@ -57,7 +57,7 @@ BC1054,Arrow Lakes Park,,British Columbia,CA,50.0194,-118.0328,ardac,353.6,False
 BC1055,Artlish Caves Park,,British Columbia,CA,50.1392,-126.9058,ardac,12.7,True,50.1195,-127.1363
 BC794,Ashcroft,,British Columbia,CA,50.721,-121.28,ardac,176.0,False,48.4584,-123.9743
 BC758,Ashton Creek,,British Columbia,CA,50.556,-119.013,ardac,301.9,False,48.5803,-124.0362
-BC443,Atlin,,British Columbia,CA,59.5679,-133.697,"ardac,ncr",93.6,True,58.6515,-134.7518
+BC443,Atlin,,British Columbia,CA,59.5679,-133.697,"ardac,awe,ncr",93.6,True,58.6515,-134.7518
 BC437,Attachie,,British Columbia,CA,56.2205,-121.423,ardac,509.6,False,53.4363,-128.9429
 BC873,Avola,,British Columbia,CA,51.7812,-119.323,ardac,356.4,False,50.9635,-126.2679
 BC1056,Babine Lake Marine Park,,British Columbia,CA,54.675,-125.8915,ardac,189.7,False,53.4634,-128.9321
@@ -80,7 +80,7 @@ BC297,Barrett Lake,,British Columbia,CA,54.45,-126.75,ardac,129.0,False,53.5714,
 BC456,Barriere,,British Columbia,CA,51.1819,-120.133,ardac,271.0,False,48.4739,-123.9385
 BC1062,Baynes Island Ecological Reserve,,British Columbia,CA,49.7723,-123.1742,ardac,7.5,True,48.6085,-123.9678
 BC569,Baynes Lake,,British Columbia,CA,49.2333,-115.217,ardac,531.9,False,,
-BC991,Bear Camp,,British Columbia,CA,59.9167,-136.8,"ardac,ncr",95.3,True,58.9493,-138.102
+BC991,Bear Camp,,British Columbia,CA,59.9167,-136.8,"ardac,awe,ncr",95.3,True,58.9493,-138.102
 BC23,Bear Creek,,British Columbia,CA,49.529,-121.761,ardac,80.0,True,48.5744,-123.8205
 BC1063,Bear Creek Park,,British Columbia,CA,49.9295,-119.5198,ardac,246.8,False,48.5877,-123.9334
 BC730,Bear Flat,,British Columbia,CA,56.274,-121.231,ardac,522.0,False,53.494,-129.0529
@@ -106,7 +106,7 @@ BC861,Bella Bella,,British Columbia,CA,52.1639,-128.144,ardac,2.0,True,52.1469,-
 BC746,Bella Coola,,British Columbia,CA,52.3706,-126.752,ardac,1.2,True,52.0103,-127.7951
 BC1073,Bella Coola Estuary Conservancy,,British Columbia,CA,52.381,-126.7728,ardac,1.1,True,52.0205,-127.816
 BC1074,Bellhouse Park,,British Columbia,CA,48.8722,-123.3119,ardac,0.5,True,48.5379,-124.0536
-BC614,Bennett,,British Columbia,CA,59.8451,-134.987,"ardac,ncr",46.4,True,58.6565,-134.9829
+BC614,Bennett,,British Columbia,CA,59.8451,-134.987,"ardac,awe,ncr",46.4,True,58.6565,-134.9829
 BC1075,Beresford Island Ecological Reserve,,British Columbia,CA,50.79,-128.7754,ardac,5.0,True,50.7731,-128.7466
 BC970,Bessborough,,British Columbia,CA,55.8109,-120.506,ardac,535.1,False,52.4211,-127.9868
 BC156,Big Bar Creek,,British Columbia,CA,51.1829,-122.117,ardac,166.2,False,50.9,-126.3193
@@ -525,7 +525,7 @@ BC1238,Francis Point Park,,British Columbia,CA,49.6121,-124.0571,ardac,1.2,True,
 BC1239,Francois Lake Protected Area,,British Columbia,CA,53.9863,-125.0399,ardac,181.7,False,53.4403,-128.9239
 BC89,Franklin Camp,,British Columbia,CA,48.9722,-124.742,ardac,9.4,True,48.7907,-124.9712
 BC1004,François Lake,,British Columbia,CA,54.0517,-125.7419,ardac,157.1,False,53.4987,-129.0644
-BC944,Fraser,,British Columbia,CA,59.7159,-135.049,"ardac,ncr",32.1,True,58.7129,-134.7676
+BC944,Fraser,,British Columbia,CA,59.7159,-135.049,"ardac,awe,ncr",32.1,True,58.7129,-134.7676
 BC759,Fraser Lake,,British Columbia,CA,54.0583,-124.847,ardac,196.4,False,53.5117,-129.0193
 BC1240,Fraser River Ecological Reserve,,British Columbia,CA,49.1741,-122.0188,ardac,57.2,True,48.5469,-124.0439
 BC1241,French Beach Park,,British Columbia,CA,48.3927,-123.9426,ardac,4.8,True,48.3746,-123.917
@@ -1123,7 +1123,7 @@ BC1478,Pinnacles Park,,British Columbia,CA,52.9791,-122.5605,ardac,276.1,False,5
 BC1479,Pirates Cove Marine Park,,British Columbia,CA,49.0959,-123.7253,ardac,1.7,True,48.5842,-123.9734
 BC617,Pitt Meadows,,British Columbia,CA,49.2172,-122.686,ardac,19.5,True,48.5657,-123.9548
 BC1480,Pitt Polder Ecological Reserve,,British Columbia,CA,49.324,-122.6387,ardac,18.5,True,48.5069,-123.9184
-BC963,Pleasant Camp,,British Columbia,CA,59.4546,-136.365,"ardac,ncr",47.9,True,58.6189,-136.095
+BC963,Pleasant Camp,,British Columbia,CA,59.4546,-136.365,"ardac,awe,ncr",47.9,True,58.6189,-136.095
 BC666,Pleasantside,,British Columbia,CA,49.2934,-122.847,ardac,5.5,True,48.4691,-123.8731
 BC1481,Plumper Cove Marine Park,,British Columbia,CA,49.4047,-123.4666,ardac,1.6,True,48.5664,-123.9849
 BC356,Pope Landing,,British Columbia,CA,49.6145,-124.048,ardac,1.0,True,48.9455,-125.0564
@@ -1469,7 +1469,7 @@ BC1613,Takla Lake Marine Park,,British Columbia,CA,55.4163,-125.9327,ardac,223.6
 BC559,Takla Landing,,British Columbia,CA,55.483,-125.974,ardac,220.8,False,54.565,-130.2404
 BC365,Takysie Lake,,British Columbia,CA,53.8833,-125.867,ardac,137.0,False,53.4995,-128.9082
 BC850,Tappen,,British Columbia,CA,50.784,-119.331,ardac,292.7,False,48.4526,-123.8778
-BC1614,Tarahne Park,,British Columbia,CA,59.5779,-133.7046,"ardac,ncr",93.3,True,58.6615,-134.7595
+BC1614,Tarahne Park,,British Columbia,CA,59.5779,-133.7046,"ardac,awe,ncr",93.3,True,58.6615,-134.7595
 BC152,Tatalrose,,British Columbia,CA,53.9833,-125.983,ardac,142.2,False,53.4312,-129.0184
 BC107,Tatla Lake,,British Columbia,CA,51.9,-124.6,ardac,109.1,False,50.8964,-126.18
 BC186,Tatlayoko Lake,,British Columbia,CA,51.7167,-124.433,ardac,91.8,True,50.8808,-126.2729

--- a/vector_data/point/yukon_point_locations.csv
+++ b/vector_data/point/yukon_point_locations.csv
@@ -1,77 +1,77 @@
 id,name,alt_name,region,country,latitude,longitude,tags,km_distance_to_ocean,is_coastal,ocean_lat1,ocean_lon1
-YT1,Aishihik,,Yukon,CA,61.5986,-137.508,"ardac,ncr",204.1,False,59.8664,-139.7582
-YT2,Bear Creek,,Yukon,CA,60.7975,-137.67,"ardac,ncr",128.3,False,59.8766,-139.7248
-YT4,Beaver Creek,,Yukon,CA,62.3833,-140.875,"ardac,ncr",251.1,False,60.1489,-142.5156
-YT5,Braeburn,,Yukon,CA,61.4815,-135.748,"ardac,ncr",224.9,False,59.8585,-139.6952
-YT6,Brooks Brook,,Yukon,CA,60.4189,-133.191,"ardac,ncr",160.3,False,58.9365,-134.9829
-YT7,Burwash Landing,,Yukon,CA,61.3542,-138.994,"ardac,ncr",147.8,False,59.8555,-139.6158
-YT8,Canyon City,,Yukon,CA,60.6344,-134.774,"ardac,ncr",133.4,False,58.844,-135.2371
-YT9,Carcross,,Yukon,CA,60.1694,-134.701,"ardac,ncr",85.8,True,58.8596,-135.2003
-YT74,Carcross Cutoff,,Yukon,CA,60.5958,-134.878,"ardac,ncr",127.9,False,58.9722,-135.04
-YT10,Carmacks,,Yukon,CA,62.0888,-136.284,"ardac,ncr",286.4,False,59.8322,-139.8085
-YT11,Champagne,,Yukon,CA,60.7889,-136.479,"ardac,ncr",159.6,False,59.8375,-139.5157
-YT75,Clinton Creek,,Yukon,CA,64.415,-140.602,"ardac,ncr",461.0,False,60.2143,-142.7299
-YT12,Conrad,,Yukon,CA,60.0691,-134.564,"ardac,ncr",79.9,True,58.9201,-135.0797
-YT13,Cowley,,Yukon,CA,60.5253,-134.897,"ardac,ncr",120.0,False,58.9015,-135.0577
-YT14,Crestview,,Yukon,CA,60.8231,-135.204,"ardac,ncr",150.7,False,58.8856,-135.0153
-YT15,Dalton Post,,Yukon,CA,60.12,-137.025,"ardac,ncr",110.2,False,59.0807,-138.4068
-YT16,Dawson City,,Yukon,CA,64.0625,-139.431,"ardac,ncr",447.1,False,59.8438,-139.7589
-YT17,Destruction Bay,,Yukon,CA,61.2542,-138.807,"ardac,ncr",139.5,False,59.8976,-139.7864
-YT18,Dezadeash,,Yukon,CA,60.3722,-137.056,"ardac,ncr",120.0,False,59.4608,-139.1015
-YT19,Dry Creek,,Yukon,CA,62.1725,-140.6856,"ardac,ncr",229.2,False,60.0731,-142.6939
-YT20,Eagle Plains,,Yukon,CA,66.371,-136.72,"ardac,ncr",263.2,False,68.6095,-136.2093
-YT21,Elsa,,Yukon,CA,63.9076,-135.476,"ardac,ncr",479.0,False,59.8869,-139.534
-YT22,Faro,,Yukon,CA,62.2274,-133.35,"ardac,ncr",325.6,False,58.983,-135.0918
-YT23,Fort Selkirk,,Yukon,CA,62.7723,-137.394,"ardac,ncr",323.7,False,59.911,-139.799
-YT24,Forty Mile,,Yukon,CA,64.4269,-140.533,"ardac,ncr",463.8,False,60.749,-145.8355
+YT1,Aishihik,,Yukon,CA,61.5986,-137.508,"ardac,awe,ncr",204.1,False,59.8664,-139.7582
+YT2,Bear Creek,,Yukon,CA,60.7975,-137.67,"ardac,awe,ncr",128.3,False,59.8766,-139.7248
+YT4,Beaver Creek,,Yukon,CA,62.3833,-140.875,"ardac,awe,ncr",251.1,False,60.1489,-142.5156
+YT5,Braeburn,,Yukon,CA,61.4815,-135.748,"ardac,awe,ncr",224.9,False,59.8585,-139.6952
+YT6,Brooks Brook,,Yukon,CA,60.4189,-133.191,"ardac,awe,ncr",160.3,False,58.9365,-134.9829
+YT7,Burwash Landing,,Yukon,CA,61.3542,-138.994,"ardac,awe,ncr",147.8,False,59.8555,-139.6158
+YT8,Canyon City,,Yukon,CA,60.6344,-134.774,"ardac,awe,ncr",133.4,False,58.844,-135.2371
+YT9,Carcross,,Yukon,CA,60.1694,-134.701,"ardac,awe,ncr",85.8,True,58.8596,-135.2003
+YT74,Carcross Cutoff,,Yukon,CA,60.5958,-134.878,"ardac,awe,ncr",127.9,False,58.9722,-135.04
+YT10,Carmacks,,Yukon,CA,62.0888,-136.284,"ardac,awe,ncr",286.4,False,59.8322,-139.8085
+YT11,Champagne,,Yukon,CA,60.7889,-136.479,"ardac,awe,ncr",159.6,False,59.8375,-139.5157
+YT75,Clinton Creek,,Yukon,CA,64.415,-140.602,"ardac,awe,ncr",461.0,False,60.2143,-142.7299
+YT12,Conrad,,Yukon,CA,60.0691,-134.564,"ardac,awe,ncr",79.9,True,58.9201,-135.0797
+YT13,Cowley,,Yukon,CA,60.5253,-134.897,"ardac,awe,ncr",120.0,False,58.9015,-135.0577
+YT14,Crestview,,Yukon,CA,60.8231,-135.204,"ardac,awe,ncr",150.7,False,58.8856,-135.0153
+YT15,Dalton Post,,Yukon,CA,60.12,-137.025,"ardac,awe,ncr",110.2,False,59.0807,-138.4068
+YT16,Dawson City,,Yukon,CA,64.0625,-139.431,"ardac,awe,ncr",447.1,False,59.8438,-139.7589
+YT17,Destruction Bay,,Yukon,CA,61.2542,-138.807,"ardac,awe,ncr",139.5,False,59.8976,-139.7864
+YT18,Dezadeash,,Yukon,CA,60.3722,-137.056,"ardac,awe,ncr",120.0,False,59.4608,-139.1015
+YT19,Dry Creek,,Yukon,CA,62.1725,-140.6856,"ardac,awe,ncr",229.2,False,60.0731,-142.6939
+YT20,Eagle Plains,,Yukon,CA,66.371,-136.72,"ardac,awe,ncr",263.2,False,68.6095,-136.2093
+YT21,Elsa,,Yukon,CA,63.9076,-135.476,"ardac,awe,ncr",479.0,False,59.8869,-139.534
+YT22,Faro,,Yukon,CA,62.2274,-133.35,"ardac,awe,ncr",325.6,False,58.983,-135.0918
+YT23,Fort Selkirk,,Yukon,CA,62.7723,-137.394,"ardac,awe,ncr",323.7,False,59.911,-139.799
+YT24,Forty Mile,,Yukon,CA,64.4269,-140.533,"ardac,awe,ncr",463.8,False,60.749,-145.8355
 YT25,Frances Lake,,Yukon,CA,61.2757,-129.275,"ardac,ncr",390.8,False,58.8689,-135.0277
-YT26,Haines Junction,,Yukon,CA,60.7559,-137.504,"ardac,ncr",130.2,False,59.8376,-139.561
-YT27,Herschel Island,Qikiqtaruk,Yukon,CA,69.5727,-138.901,ardac,0.6,True,69.5589,-138.8527
-YT28,Ibex Valley,,Yukon,CA,60.8494,-135.639,"ardac,ncr",154.2,False,58.9197,-135.1164
-YT29,Jakes Corner,,Yukon,CA,60.3386,-133.984,"ardac,ncr",123.2,False,58.8598,-135.1204
-YT30,Johnsons Crossing,,Yukon,CA,60.4889,-133.297,"ardac,ncr",161.2,False,59.0051,-135.0879
-YT31,Keno City,,Yukon,CA,63.9083,-135.303,"ardac,ncr",483.2,False,59.8747,-139.699
-YT32,Kloo Lake,,Yukon,CA,60.921,-137.857,"ardac,ncr",133.1,False,59.8562,-139.5619
-YT33,Klukshu,,Yukon,CA,60.2945,-137.004,"ardac,ncr",118.4,False,59.8274,-139.7754
-YT34,Koidern,,Yukon,CA,61.9833,-140.492,"ardac,ncr",210.5,False,60.203,-142.6021
-YT35,Lewis,,Yukon,CA,60.333,-134.8328,"ardac,ncr",100.2,False,58.8693,-135.0079
-YT36,Little Gold Creek,,Yukon,CA,64.0861,-141.0,"ardac,ncr",419.6,False,60.0886,-142.4753
-YT37,Little River,,Yukon,CA,60.8787,-135.6908,"ardac,ncr",157.8,False,58.9493,-135.1647
-YT38,Little Salmon/Carmacks First Nation,,Yukon,CA,62.0561,-135.701,"ardac,ncr",288.5,False,59.7973,-139.5789
-YT39,Little Teslin Lake,,Yukon,CA,60.4819,-133.465,"ardac,ncr",154.1,False,58.9957,-135.2479
-YT40,Marsh Lake,,Yukon,CA,60.5193,-134.332,"ardac,ncr",129.7,False,58.8845,-135.1366
-YT41,Mayo,,Yukon,CA,63.5931,-135.896,"ardac,ncr",438.3,False,59.8969,-139.619
-YT42,McCabe Creek,,Yukon,CA,62.5284,-136.784,"ardac,ncr",312.5,False,59.8192,-139.5744
-YT43,Mendenhall Landing,,Yukon,CA,60.7528,-136.039,"ardac,ncr",147.7,False,58.9921,-135.2003
-YT44,Minto,,Yukon,CA,62.5848,-136.851,"ardac,ncr",316.3,False,59.8744,-139.6405
+YT26,Haines Junction,,Yukon,CA,60.7559,-137.504,"ardac,awe,ncr",130.2,False,59.8376,-139.561
+YT27,Herschel Island,Qikiqtaruk,Yukon,CA,69.5727,-138.901,"ardac,awe",0.6,True,69.5589,-138.8527
+YT28,Ibex Valley,,Yukon,CA,60.8494,-135.639,"ardac,awe,ncr",154.2,False,58.9197,-135.1164
+YT29,Jakes Corner,,Yukon,CA,60.3386,-133.984,"ardac,awe,ncr",123.2,False,58.8598,-135.1204
+YT30,Johnsons Crossing,,Yukon,CA,60.4889,-133.297,"ardac,awe,ncr",161.2,False,59.0051,-135.0879
+YT31,Keno City,,Yukon,CA,63.9083,-135.303,"ardac,awe,ncr",483.2,False,59.8747,-139.699
+YT32,Kloo Lake,,Yukon,CA,60.921,-137.857,"ardac,awe,ncr",133.1,False,59.8562,-139.5619
+YT33,Klukshu,,Yukon,CA,60.2945,-137.004,"ardac,awe,ncr",118.4,False,59.8274,-139.7754
+YT34,Koidern,,Yukon,CA,61.9833,-140.492,"ardac,awe,ncr",210.5,False,60.203,-142.6021
+YT35,Lewis,,Yukon,CA,60.333,-134.8328,"ardac,awe,ncr",100.2,False,58.8693,-135.0079
+YT36,Little Gold Creek,,Yukon,CA,64.0861,-141.0,"ardac,awe,ncr",419.6,False,60.0886,-142.4753
+YT37,Little River,,Yukon,CA,60.8787,-135.6908,"ardac,awe,ncr",157.8,False,58.9493,-135.1647
+YT38,Little Salmon/Carmacks First Nation,,Yukon,CA,62.0561,-135.701,"ardac,awe,ncr",288.5,False,59.7973,-139.5789
+YT39,Little Teslin Lake,,Yukon,CA,60.4819,-133.465,"ardac,awe,ncr",154.1,False,58.9957,-135.2479
+YT40,Marsh Lake,,Yukon,CA,60.5193,-134.332,"ardac,awe,ncr",129.7,False,58.8845,-135.1366
+YT41,Mayo,,Yukon,CA,63.5931,-135.896,"ardac,awe,ncr",438.3,False,59.8969,-139.619
+YT42,McCabe Creek,,Yukon,CA,62.5284,-136.784,"ardac,awe,ncr",312.5,False,59.8192,-139.5744
+YT43,Mendenhall Landing,,Yukon,CA,60.7528,-136.039,"ardac,awe,ncr",147.7,False,58.9921,-135.2003
+YT44,Minto,,Yukon,CA,62.5848,-136.851,"ardac,awe,ncr",316.3,False,59.8744,-139.6405
 YT45,Morley River,,Yukon,CA,60.013,-132.162,"ardac,ncr",189.2,False,59.0047,-135.2368
-YT46,Mount Lorne,,Yukon,CA,60.4126,-134.952,"ardac,ncr",107.1,False,58.9489,-135.1222
-YT76,Nesketahin,Wesketahin,Yukon,CA,60.1334,-137.057,"ardac,ncr",108.9,False,59.0937,-138.4383
-YT47,Old Crow,,Yukon,CA,67.5729,-139.829,"ardac,ncr",187.0,False,68.926,-137.5464
-YT48,Pelly Crossing,,Yukon,CA,62.8198,-136.574,"ardac,ncr",346.1,False,59.9384,-139.69
-YT49,Porter Creek,,Yukon,CA,60.7699,-135.136,"ardac,ncr",145.0,False,58.986,-135.2725
-YT50,Quill Creek,,Yukon,CA,61.5079,-139.3306,"ardac,ncr",162.5,False,59.8669,-139.5869
-YT51,Rampart House,,Yukon,CA,67.4219,-140.993,"ardac,ncr",225.6,False,69.2684,-138.9274
+YT46,Mount Lorne,,Yukon,CA,60.4126,-134.952,"ardac,awe,ncr",107.1,False,58.9489,-135.1222
+YT76,Nesketahin,Wesketahin,Yukon,CA,60.1334,-137.057,"ardac,awe,ncr",108.9,False,59.0937,-138.4383
+YT47,Old Crow,,Yukon,CA,67.5729,-139.829,"ardac,awe,ncr",187.0,False,68.926,-137.5464
+YT48,Pelly Crossing,,Yukon,CA,62.8198,-136.574,"ardac,awe,ncr",346.1,False,59.9384,-139.69
+YT49,Porter Creek,,Yukon,CA,60.7699,-135.136,"ardac,awe,ncr",145.0,False,58.986,-135.2725
+YT50,Quill Creek,,Yukon,CA,61.5079,-139.3306,"ardac,awe,ncr",162.5,False,59.8669,-139.5869
+YT51,Rampart House,,Yukon,CA,67.4219,-140.993,"ardac,awe,ncr",225.6,False,69.2684,-138.9274
 YT52,Rancheria,,Yukon,CA,60.0875,-130.603,"ardac,ncr",250.8,False,58.9318,-135.2707
-YT53,Riverdale,,Yukon,CA,60.7069,-135.024,"ardac,ncr",138.7,False,58.923,-135.1663
-YT54,Robinson,,Yukon,CA,60.4512,-134.846,"ardac,ncr",112.6,False,58.9878,-135.0211
-YT55,Ross River,,Yukon,CA,61.9779,-132.449,"ardac,ncr",320.8,False,58.888,-135.1991
-YT56,Snag,,Yukon,CA,62.4,-140.367,"ardac,ncr",257.3,False,60.1222,-142.6777
-YT57,Snag Junction,,Yukon,CA,62.2348,-140.692,"ardac,ncr",236.0,False,60.1354,-142.7039
-YT58,Stewart Crossing,,Yukon,CA,63.3675,-136.679,"ardac,ncr",398.8,False,59.8477,-139.6931
-YT59,Stewart River,Nä`chòo ndek,Yukon,CA,63.2917,-139.4117,"ardac,ncr",361.1,False,59.8849,-139.5995
-YT60,Stony Creek Camp,,Yukon,CA,60.801,-135.976,"ardac,ncr",152.1,False,58.8796,-135.1266
+YT53,Riverdale,,Yukon,CA,60.7069,-135.024,"ardac,awe,ncr",138.7,False,58.923,-135.1663
+YT54,Robinson,,Yukon,CA,60.4512,-134.846,"ardac,awe,ncr",112.6,False,58.9878,-135.0211
+YT55,Ross River,,Yukon,CA,61.9779,-132.449,"ardac,awe,ncr",320.8,False,58.888,-135.1991
+YT56,Snag,,Yukon,CA,62.4,-140.367,"ardac,awe,ncr",257.3,False,60.1222,-142.6777
+YT57,Snag Junction,,Yukon,CA,62.2348,-140.692,"ardac,awe,ncr",236.0,False,60.1354,-142.7039
+YT58,Stewart Crossing,,Yukon,CA,63.3675,-136.679,"ardac,awe,ncr",398.8,False,59.8477,-139.6931
+YT59,Stewart River,Nä`chòo ndek,Yukon,CA,63.2917,-139.4117,"ardac,awe,ncr",361.1,False,59.8849,-139.5995
+YT60,Stony Creek Camp,,Yukon,CA,60.801,-135.976,"ardac,awe,ncr",152.1,False,58.8796,-135.1266
 YT61,Swift River,,Yukon,CA,60.0042,-131.187,"ardac,ncr",221.0,False,59.0027,-135.2192
-YT62,Tagish,,Yukon,CA,60.31,-134.266,"ardac,ncr",111.3,False,58.996,-135.0939
-YT77,Tagish Narrows Habitat Protection Area,,Yukon,CA,60.3046,-134.2631,"ardac,ncr",110.9,False,58.9907,-135.0909
-YT63,Takhini,,Yukon,CA,60.8533,-135.447,"ardac,ncr",153.9,False,58.9163,-135.2438
-YT64,Ten Mile,,Yukon,CA,60.1667,-134.367,"ardac,ncr",95.0,True,58.8518,-135.1872
+YT62,Tagish,,Yukon,CA,60.31,-134.266,"ardac,awe,ncr",111.3,False,58.996,-135.0939
+YT77,Tagish Narrows Habitat Protection Area,,Yukon,CA,60.3046,-134.2631,"ardac,awe,ncr",110.9,False,58.9907,-135.0909
+YT63,Takhini,,Yukon,CA,60.8533,-135.447,"ardac,awe,ncr",153.9,False,58.9163,-135.2438
+YT64,Ten Mile,,Yukon,CA,60.1667,-134.367,"ardac,awe,ncr",95.0,True,58.8518,-135.1872
 YT65,Teslin,ᑦᐁᔅᓕᓐᑦᐆ / Desleen,Yukon,CA,60.1683,-132.719,"ardac,ncr",166.9,False,59.0012,-135.1566
 YT66,Teslin Lake,,Yukon,CA,60.0167,-132.4333,"ardac,ncr",175.0,False,58.8486,-135.1777
 YT67,Tuchitua,,Yukon,CA,60.9025,-129.2505,"ardac,ncr",367.1,False,58.9719,-135.2852
 YT69,Two Mile Village,,Yukon,CA,60.1254,-128.804,"ardac,ncr",334.6,False,57.751,-133.5041
 YT68,Two and One-Half Mile Village,,Yukon,CA,60.1434,-128.881,"ardac,ncr",331.9,False,57.7661,-133.578
-YT70,Upper Laberge,,Yukon,CA,60.9509,-135.132,"ardac,ncr",165.1,False,58.8466,-135.2426
+YT70,Upper Laberge,,Yukon,CA,60.9509,-135.132,"ardac,awe,ncr",165.1,False,58.8466,-135.2426
 YT71,Upper Liard,,Yukon,CA,60.0545,-128.923,"ardac,ncr",324.9,False,57.8364,-133.61
 YT72,Watson Lake,,Yukon,CA,60.0639,-128.706,"ardac,ncr",336.0,False,57.8539,-133.4089
-YT73,Whitehorse,,Yukon,CA,60.727,-135.074,"ardac,ncr",140.6,False,58.9431,-135.2137
+YT73,Whitehorse,,Yukon,CA,60.727,-135.074,"ardac,awe,ncr",140.6,False,58.9431,-135.2137


### PR DESCRIPTION
Closes #152.

This PR modifies the `tag_point_locations.py` script to tag all Canadian communities that fall within the `aqi_forecast_24_hrs.tif` GeoTIFF bounds with the `awe` (Alaska Wildfire Explorer) tag.

Previously, the Alaska Wildfire Explorer was fetching all Alaskan + Canadian communities used by Northern Climate Reports, but the `aqi_forecast_*_hrs.tif` GeoTIFFs don't cover the same area as the IEM extent, so doing the extra work of determining which Canadian communities fall within the `aqi_forecast_24_hrs.tif` extent makes for a much better user experience (i.e., no more "dead end" Canadian communities).

Here's a screenshot of an `aqi_forecast_24_hrs.tif` file masked by a coastline GeoJSON for reference:

![image](https://github.com/user-attachments/assets/5be048dd-7676-4573-a7e2-baa6e005ec9f)

I am not tagging Russian communities with the `awe` tag, however, even though AQI data exists for Russia because this would require non-trivial code changes on the webapp side to support.

To test, take a look at the `tag_point_locations.py` code diff and also spot check the communities with/without the `awe` tag in the Yukon and British Columbia CSVs to verify that they make sense vs. the screenshot above.